### PR TITLE
[Watchdog Gem] Disable Dependency testing for monolithic build

### DIFF
--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
@@ -57,7 +57,9 @@ namespace WatchdogTools
     void WatchdogToolsSystemComponent::Activate()
     {
         WatchdogToolsRequestBus::Handler::BusConnect();
+#if !defined(AZ_MONOLITHIC_BUILD)
         CheckRequiredModules();
+#endif
     }
 
     void WatchdogToolsSystemComponent::Deactivate()


### PR DESCRIPTION
This PR disables dependency testing in a monolithic build.

I have rebased a branch on top of the current main.