### PR TITLE
Implement PrefabVariantComponent in LevelModificationTools

### DIFF
--- a/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsBus.h
+++ b/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsBus.h
@@ -8,33 +8,31 @@
 
 #pragma once
 
-#include <LevelModificationTools/LevelModificationToolsTypeIds.h>
-
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <LevelModificationTools/LevelModificationToolsTypeIds.h>
 
 namespace LevelModificationTools
 {
-    class LevelModificationToolsRequests
+    class LevelModificationToolsRequests : public AZ::EBusTraits
     {
     public:
         AZ_RTTI(LevelModificationToolsRequests, LevelModificationToolsRequestsTypeId);
+
+        using BusIdType = AZ::s32;
+        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+
         virtual ~LevelModificationToolsRequests() = default;
-        // Put your public methods here
+
+        //! Loads a prefab variant.
+        //! @param variantId The id of the prefab variant to load, or -1 to empty.
+        virtual void SetPrefabVariant(AZ::s32 variantId) = 0;
+
+        static void Reflect(AZ::ReflectContext* context);
     };
 
-    class LevelModificationToolsBusTraits
-        : public AZ::EBusTraits
-    {
-    public:
-        //////////////////////////////////////////////////////////////////////////
-        // EBusTraits overrides
-        static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-        //////////////////////////////////////////////////////////////////////////
-    };
-
-    using LevelModificationToolsRequestBus = AZ::EBus<LevelModificationToolsRequests, LevelModificationToolsBusTraits>;
-    using LevelModificationToolsInterface = AZ::Interface<LevelModificationToolsRequests>;
+    using LevelModificationToolsRequestBus = AZ::EBus<LevelModificationToolsRequests>;
 
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsTypeIds.h
+++ b/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsTypeIds.h
@@ -23,4 +23,6 @@ namespace LevelModificationTools
 
     // Interface TypeIds
     inline constexpr const char* LevelModificationToolsRequestsTypeId = "{7FFB3A2A-B9D6-4B5E-9B86-0105A7DDDC25}";
+
+    inline constexpr const char* PrefabVariantConfigTypeId = "{018f864b-d24e-79eb-b584-b445aae95dda}";
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsTypeIds.h
+++ b/Gems/LevelModificationTools/Code/Include/LevelModificationTools/LevelModificationToolsTypeIds.h
@@ -22,7 +22,7 @@ namespace LevelModificationTools
     inline constexpr const char* LevelModificationToolsEditorModuleTypeId = LevelModificationToolsModuleTypeId;
 
     // Interface TypeIds
-    inline constexpr const char* LevelModificationToolsRequestsTypeId = "{7FFB3A2A-B9D6-4B5E-9B86-0105A7DDDC25}";
+    inline constexpr const char* PrefabVariantRequestsTypeId = "{7FFB3A2A-B9D6-4B5E-9B86-0105A7DDDC25}";
 
     inline constexpr const char* PrefabVariantConfigTypeId = "{018f864b-d24e-79eb-b584-b445aae95dda}";
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Include/LevelModificationTools/PrefabVariantRequestsBus.h
+++ b/Gems/LevelModificationTools/Code/Include/LevelModificationTools/PrefabVariantRequestsBus.h
@@ -15,16 +15,16 @@
 
 namespace LevelModificationTools
 {
-    class LevelModificationToolsRequests : public AZ::EBusTraits
+    class PrefabVariantRequests : public AZ::EBusTraits
     {
     public:
-        AZ_RTTI(LevelModificationToolsRequests, LevelModificationToolsRequestsTypeId);
+        AZ_RTTI(PrefabVariantRequests, PrefabVariantRequestsTypeId);
 
         using BusIdType = AZ::s32;
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
 
-        virtual ~LevelModificationToolsRequests() = default;
+        virtual ~PrefabVariantRequests() = default;
 
         //! Loads a prefab variant.
         //! @param variantId The id of the prefab variant to load, or -1 to empty.
@@ -33,6 +33,6 @@ namespace LevelModificationTools
         static void Reflect(AZ::ReflectContext* context);
     };
 
-    using LevelModificationToolsRequestBus = AZ::EBus<LevelModificationToolsRequests>;
+    using PrefabVariantRequestsBus = AZ::EBus<PrefabVariantRequests>;
 
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
@@ -18,8 +18,10 @@ namespace LevelModificationTools
                 ->Attribute(AZ::Script::Attributes::Category, "LevelModificationTools")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, "LevelModificationTools")
-                ->Event("SetPrefabVariant", &LevelModificationToolsRequestBus::Events::SetPrefabVariant,
-                                            {{{"Variant", "Number of variant to load, or -1 to clear"}}});
+                ->Event(
+                    "SetPrefabVariant",
+                    &LevelModificationToolsRequestBus::Events::SetPrefabVariant,
+                    { { { "Variant", "Number of variant to load, or -1 to clear" } } });
         }
     }
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <LevelModificationTools/LevelModificationToolsBus.h>
+
+namespace LevelModificationTools
+{
+    void LevelModificationToolsRequests::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->EBus<LevelModificationToolsRequestBus>("LevelModificationToolsRequestBus")
+                ->Attribute(AZ::Script::Attributes::Category, "LevelModificationTools")
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Module, "LevelModificationTools")
+                ->Event("SetPrefabVariant", &LevelModificationToolsRequestBus::Events::SetPrefabVariant,
+                                            {{{"Variant", "Number of variant to load, or -1 to clear"}}});
+        }
+    }
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsBus.cpp
@@ -6,21 +6,21 @@
  *
  */
 
-#include <LevelModificationTools/LevelModificationToolsBus.h>
+#include <LevelModificationTools/PrefabVariantRequestsBus.h>
 
 namespace LevelModificationTools
 {
-    void LevelModificationToolsRequests::Reflect(AZ::ReflectContext* context)
+    void PrefabVariantRequests::Reflect(AZ::ReflectContext* context)
     {
         if (auto* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
-            behaviorContext->EBus<LevelModificationToolsRequestBus>("LevelModificationToolsRequestBus")
+            behaviorContext->EBus<PrefabVariantRequestsBus>("PrefabVariantRequestsBus")
                 ->Attribute(AZ::Script::Attributes::Category, "LevelModificationTools")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, "LevelModificationTools")
                 ->Event(
                     "SetPrefabVariant",
-                    &LevelModificationToolsRequestBus::Events::SetPrefabVariant,
+                    &PrefabVariantRequestsBus::Events::SetPrefabVariant,
                     { { { "Variant", "Number of variant to load, or -1 to clear" } } });
         }
     }

--- a/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsModule.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/LevelModificationToolsModule.cpp
@@ -11,13 +11,12 @@
 
 namespace LevelModificationTools
 {
-    class LevelModificationToolsModule
-        : public LevelModificationToolsModuleInterface
+    class LevelModificationToolsModule : public LevelModificationToolsModuleInterface
     {
     public:
         AZ_RTTI(LevelModificationToolsModule, LevelModificationToolsModuleTypeId, LevelModificationToolsModuleInterface);
         AZ_CLASS_ALLOCATOR(LevelModificationToolsModule, AZ::SystemAllocator);
     };
-}// namespace LevelModificationTools
+} // namespace LevelModificationTools
 
 AZ_DECLARE_MODULE_CLASS(Gem_LevelModificationTools, LevelModificationTools::LevelModificationToolsModule)

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PrefabVariantComponent.h"
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzFramework/Components/TransformComponent.h>
+#include <LevelModificationTools/LevelModificationToolsBus.h>
+
+namespace LevelModificationTools
+{
+    PrefabVariantComponent::PrefabVariantComponent(const LevelModificationTools::PrefabVariantConfig& config)
+        : m_config(config)
+    {
+
+    }
+    void PrefabVariantComponent::Activate()
+    {
+        if (m_config.m_defaultPrefabVariant)
+        {
+            SpawnPrefab(m_config.m_defaultPrefabVariant);
+        }
+        LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+    }
+
+    void PrefabVariantComponent::Deactivate()
+    {
+        LevelModificationToolsRequestBus::Handler::BusDisconnect();
+    }
+
+
+    void PrefabVariantComponent::SpawnPrefab( AZ::Data::Asset<AzFramework::Spawnable> prefabAsset)
+    {
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+
+        // Spawn the prefab variant
+        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+        AZ_Assert(spawner, "SpawnableEntitiesDefinition not found.");
+
+        AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+
+        optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
+        {
+            AZ::Entity* root = *view.begin();
+            auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+            transformInterface->SetWorldTM(transform);
+        };
+        optionalArgs.m_completionCallback = [this](auto ticket, auto result)
+        {
+            if (!result.empty())
+            {
+                const AZ::Entity* root = *result.begin();
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetParent(GetEntityId());
+            }
+        };
+
+        optionalArgs.m_priority = AzFramework::SpawnablePriority_Low;
+        AzFramework::EntitySpawnTicket ticket(prefabAsset);
+        spawner->SpawnAllEntities(ticket, optionalArgs);
+        m_spawnTicket = ticket;
+    }
+
+    void PrefabVariantComponent::SetPrefabVariant(AZ::s32 variantId)
+    {
+        if (variantId < 0)
+        {
+            m_spawnTicket = AzFramework::EntitySpawnTicket();
+        }
+
+        const auto assetIter = m_config.m_prefabVariants.find(variantId);
+        AZ_Warning("PrefabVariantComponent", assetIter != m_config.m_prefabVariants.end(), "Prefab variant with id %d not found.", variantId);
+        if (assetIter != m_config.m_prefabVariants.end())
+        {
+            SpawnPrefab(assetIter->second);
+        }
+    }
+
+    void PrefabVariantComponent::Reflect(AZ::ReflectContext* context)
+    {
+        LevelModificationToolsRequests::Reflect(context);
+        PrefabVariantConfig::Reflect(context);
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PrefabVariantComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("Config", &PrefabVariantComponent::m_config);
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<PrefabVariantComponent>("Prefab Variant Component", "A component that manages prefab variants.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "LevelModificationTools")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantComponent::m_config,
+                        "Config", "The configuration for the component.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
+            }
+        }
+    }
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
@@ -11,12 +11,14 @@
 #include <AzCore/Serialization/EditContext.h>
 
 #include "SpawnPrefab.h"
-#include <LevelModificationTools/LevelModificationToolsBus.h>
+#include <LevelModificationTools/PrefabVariantRequestsBus.h>
+
+#include <utility>
 
 namespace LevelModificationTools
 {
-    PrefabVariantComponent::PrefabVariantComponent(const LevelModificationTools::PrefabVariantConfig& config)
-        : m_config(config)
+    PrefabVariantComponent::PrefabVariantComponent(PrefabVariantConfig config)
+        : m_config(std::move(config))
     {
     }
     void PrefabVariantComponent::Activate()
@@ -25,12 +27,12 @@ namespace LevelModificationTools
         {
             m_spawnTicket = SpawnPrefab(m_config.m_defaultPrefabVariant, GetEntityId());
         }
-        LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+        PrefabVariantRequestsBus::Handler::BusConnect(m_config.m_groupId);
     }
 
     void PrefabVariantComponent::Deactivate()
     {
-        LevelModificationToolsRequestBus::Handler::BusDisconnect();
+        PrefabVariantRequestsBus::Handler::BusDisconnect();
     }
 
     void PrefabVariantComponent::SetPrefabVariant(AZ::s32 variantId)
@@ -51,7 +53,7 @@ namespace LevelModificationTools
 
     void PrefabVariantComponent::Reflect(AZ::ReflectContext* context)
     {
-        LevelModificationToolsRequests::Reflect(context);
+        PrefabVariantRequests::Reflect(context);
         PrefabVariantConfig::Reflect(context);
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
@@ -9,7 +9,8 @@
 #include "PrefabVariantComponent.h"
 
 #include <AzCore/Serialization/EditContext.h>
-#include <AzFramework/Components/TransformComponent.h>
+
+#include "SpawnPrefab.h"
 #include <LevelModificationTools/LevelModificationToolsBus.h>
 
 namespace LevelModificationTools
@@ -17,13 +18,12 @@ namespace LevelModificationTools
     PrefabVariantComponent::PrefabVariantComponent(const LevelModificationTools::PrefabVariantConfig& config)
         : m_config(config)
     {
-
     }
     void PrefabVariantComponent::Activate()
     {
         if (m_config.m_defaultPrefabVariant)
         {
-            SpawnPrefab(m_config.m_defaultPrefabVariant);
+            m_spawnTicket = SpawnPrefab(m_config.m_defaultPrefabVariant, GetEntityId());
         }
         LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
     }
@@ -31,40 +31,6 @@ namespace LevelModificationTools
     void PrefabVariantComponent::Deactivate()
     {
         LevelModificationToolsRequestBus::Handler::BusDisconnect();
-    }
-
-
-    void PrefabVariantComponent::SpawnPrefab( AZ::Data::Asset<AzFramework::Spawnable> prefabAsset)
-    {
-        AZ::Transform transform = AZ::Transform::CreateIdentity();
-        AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
-
-        // Spawn the prefab variant
-        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-        AZ_Assert(spawner, "SpawnableEntitiesDefinition not found.");
-
-        AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-
-        optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
-        {
-            AZ::Entity* root = *view.begin();
-            auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
-            transformInterface->SetWorldTM(transform);
-        };
-        optionalArgs.m_completionCallback = [this](auto ticket, auto result)
-        {
-            if (!result.empty())
-            {
-                const AZ::Entity* root = *result.begin();
-                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
-                transformInterface->SetParent(GetEntityId());
-            }
-        };
-
-        optionalArgs.m_priority = AzFramework::SpawnablePriority_Low;
-        AzFramework::EntitySpawnTicket ticket(prefabAsset);
-        spawner->SpawnAllEntities(ticket, optionalArgs);
-        m_spawnTicket = ticket;
     }
 
     void PrefabVariantComponent::SetPrefabVariant(AZ::s32 variantId)
@@ -75,10 +41,11 @@ namespace LevelModificationTools
         }
 
         const auto assetIter = m_config.m_prefabVariants.find(variantId);
-        AZ_Warning("PrefabVariantComponent", assetIter != m_config.m_prefabVariants.end(), "Prefab variant with id %d not found.", variantId);
+        AZ_Warning(
+            "PrefabVariantComponent", assetIter != m_config.m_prefabVariants.end(), "Prefab variant with id %d not found.", variantId);
         if (assetIter != m_config.m_prefabVariants.end())
         {
-            SpawnPrefab(assetIter->second);
+            m_spawnTicket = SpawnPrefab(assetIter->second, GetEntityId());
         }
     }
 
@@ -88,21 +55,8 @@ namespace LevelModificationTools
         PrefabVariantConfig::Reflect(context);
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext->Class<PrefabVariantComponent, AZ::Component>()
-                ->Version(1)
-                ->Field("Config", &PrefabVariantComponent::m_config);
-            if (auto editContext = serializeContext->GetEditContext())
-            {
-                editContext->Class<PrefabVariantComponent>("Prefab Variant Component", "A component that manages prefab variants.")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "LevelModificationTools")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &PrefabVariantComponent::m_config,
-                        "Config", "The configuration for the component.")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly);
-            }
+            serializeContext->Class<PrefabVariantComponent, AZ::Component>()->Version(1)->Field(
+                "Config", &PrefabVariantComponent::m_config);
         }
     }
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.h
@@ -13,19 +13,19 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 
 #include "PrefabVariantConfig.h"
-#include <LevelModificationTools/LevelModificationToolsBus.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include <LevelModificationTools/PrefabVariantRequestsBus.h>
 
 namespace LevelModificationTools
 {
     class PrefabVariantComponent
         : public AZ::Component
-        , private LevelModificationToolsRequestBus::Handler
+        , private PrefabVariantRequestsBus::Handler
     {
     public:
         AZ_COMPONENT(PrefabVariantComponent, "{018f8611-85fc-7e0f-a879-b3a0ff793535}", AZ::Component);
         PrefabVariantComponent() = default;
-        PrefabVariantComponent(const PrefabVariantConfig& config);
+        explicit PrefabVariantComponent(PrefabVariantConfig  config);
         ~PrefabVariantComponent() override = default;
 
         // Component overrides
@@ -35,7 +35,7 @@ namespace LevelModificationTools
         static void Reflect(AZ::ReflectContext* context);
 
     private:
-        // LevelModificationToolsRequestBus::Handler overrides
+        // PrefabVariantRequestsBus::Handler overrides
         void SetPrefabVariant(AZ::s32 variantId) override;
 
         AzFramework::EntitySpawnTicket m_spawnTicket; //! Currently spawned ticket

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <LevelModificationTools/LevelModificationToolsBus.h>
+#include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include "PrefabVariantConfig.h"
+
+namespace LevelModificationTools
+{
+    class PrefabVariantComponent
+        : public AZ::Component
+        , private LevelModificationToolsRequestBus::Handler
+    {
+    public:
+        AZ_COMPONENT(PrefabVariantComponent, "{018f8611-85fc-7e0f-a879-b3a0ff793535}", AZ::Component);
+        PrefabVariantComponent() = default;
+        PrefabVariantComponent(const PrefabVariantConfig& config);
+        ~PrefabVariantComponent() override = default;
+
+
+        // Component overrides
+        void Activate() override;
+        void Deactivate() override;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+    private:
+        // LevelModificationToolsRequestBus::Handler overrides
+        void SetPrefabVariant(AZ::s32 variantId) override;
+
+        void SpawnPrefab( AZ::Data::Asset<AzFramework::Spawnable> prefabAsset);
+
+        AzFramework::EntitySpawnTicket m_spawnTicket; //! Currently spawned ticket
+        PrefabVariantConfig m_config; //! Configuration for the component
+
+    };
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.cpp
@@ -7,9 +7,9 @@
  */
 
 #include "PrefabVariantConfig.h"
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
-#include <AzCore/Asset/AssetSerializer.h>
 
 namespace LevelModificationTools
 {

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PrefabVariantConfig.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include <AzCore/Asset/AssetSerializer.h>
+
+namespace LevelModificationTools
+{
+    void PrefabVariantConfig::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PrefabVariantConfig>()
+                ->Version(1)
+                ->Field("PrefabVariants", &PrefabVariantConfig::m_prefabVariants)
+                ->Field("GroupId", &PrefabVariantConfig::m_groupId)
+                ->Field("DefaultPrefabVariant", &PrefabVariantConfig::m_defaultPrefabVariant);
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<PrefabVariantConfig>("Prefab Variant Component", "A component that manages prefab variants.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "LevelModificationTools")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantConfig::m_groupId,
+                        "Group Id",
+                        "The region id for the spawned entities.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantConfig::m_defaultPrefabVariant,
+                        "Default Prefab Variant",
+                        "The default prefab variant to spawn.")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantConfig::m_prefabVariants,
+                        "Prefab Variants",
+                        "A map of prefab variant ids to spawnable assets.");
+            }
+        }
+    }
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
@@ -1,0 +1,32 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <LevelModificationTools/LevelModificationToolsBus.h>
+#include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace LevelModificationTools
+{
+    struct PrefabVariantConfig
+    {
+        AZ_TYPE_INFO(PrefabVariantConfig, PrefabVariantConfigTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::s32 m_groupId = 0; //! Region id for the spawned entities
+        AZStd::unordered_map<AZ::s32, AZ::Data::Asset<AzFramework::Spawnable>> m_prefabVariants;
+        AZ::Data::Asset<AzFramework::Spawnable> m_defaultPrefabVariant;
+    };
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
@@ -15,8 +15,8 @@
 #include <AzCore/std/containers/unordered_map.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
-#include <LevelModificationTools/LevelModificationToolsBus.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include <LevelModificationTools/PrefabVariantRequestsBus.h>
 
 namespace LevelModificationTools
 {

--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantConfig.h
@@ -12,11 +12,11 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/containers/unordered_map.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <LevelModificationTools/LevelModificationToolsBus.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
-#include <AzCore/std/containers/unordered_map.h>
 
 namespace LevelModificationTools
 {

--- a/Gems/LevelModificationTools/Code/Source/Clients/SpawnPrefab.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/SpawnPrefab.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "SpawnPrefab.h"
+#include <AzFramework/Components/TransformComponent.h>
+
+namespace LevelModificationTools
+{
+
+    AzFramework::EntitySpawnTicket SpawnPrefab(const AZ::Data::Asset<AzFramework::Spawnable>& spawnableAsset, const AZ::EntityId parentId)
+    {
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(transform, parentId, &AZ::TransformBus::Events::GetWorldTM);
+
+        // Spawn the prefab variant
+        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+        AZ_Assert(spawner, "SpawnableEntitiesDefinition not found.");
+
+        AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+
+        optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
+        {
+            AZ::Entity* root = *view.begin();
+            auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+            transformInterface->SetWorldTM(transform);
+        };
+        optionalArgs.m_completionCallback = [parentId](auto ticket, auto result)
+        {
+            if (!result.empty())
+            {
+                const AZ::Entity* root = *result.begin();
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetParent(parentId);
+            }
+        };
+
+        optionalArgs.m_priority = AzFramework::SpawnablePriority_Low;
+        AzFramework::EntitySpawnTicket ticket(spawnableAsset);
+        spawner->SpawnAllEntities(ticket, optionalArgs);
+        return ticket;
+    }
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Clients/SpawnPrefab.h
+++ b/Gems/LevelModificationTools/Code/Source/Clients/SpawnPrefab.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+#include <AzFramework/Spawnable/Spawnable.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+
+namespace LevelModificationTools
+{
+    //! Spawn a prefab in the level, it sets the parent of the spawned entities to the parentId and returns a ticket to track the spawned
+    //! entities
+    //! @param spawnableAsset The asset of the prefab to spawn
+    //! @param parentId The parent entity id of the spawned entities
+    //! @return The spawn ticket to track the spawned entities
+    AzFramework::EntitySpawnTicket SpawnPrefab(const AZ::Data::Asset<AzFramework::Spawnable>& spawnableAsset, const AZ::EntityId parentId);
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/LevelModificationToolsModuleInterface.cpp
+++ b/Gems/LevelModificationTools/Code/Source/LevelModificationToolsModuleInterface.cpp
@@ -9,12 +9,12 @@
 #include "LevelModificationToolsModuleInterface.h"
 #include <AzCore/Memory/Memory.h>
 
+#include <Clients/PrefabVariantComponent.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
-
 namespace LevelModificationTools
 {
-    AZ_TYPE_INFO_WITH_NAME_IMPL(LevelModificationToolsModuleInterface,
-        "LevelModificationToolsModuleInterface", LevelModificationToolsModuleInterfaceTypeId);
+    AZ_TYPE_INFO_WITH_NAME_IMPL(
+        LevelModificationToolsModuleInterface, "LevelModificationToolsModuleInterface", LevelModificationToolsModuleInterfaceTypeId);
     AZ_RTTI_NO_TYPE_INFO_IMPL(LevelModificationToolsModuleInterface, AZ::Module);
     AZ_CLASS_ALLOCATOR_IMPL(LevelModificationToolsModuleInterface, AZ::SystemAllocator);
 
@@ -24,13 +24,15 @@ namespace LevelModificationTools
         // Add ALL components descriptors associated with this gem to m_descriptors.
         // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
         // This happens through the [MyComponent]::Reflect() function.
-        m_descriptors.insert(m_descriptors.end(), {
+        m_descriptors.insert(
+            m_descriptors.end(),
+            {
+                PrefabVariantComponent::CreateDescriptor(),
             });
     }
 
     AZ::ComponentTypeList LevelModificationToolsModuleInterface::GetRequiredSystemComponents() const
     {
-        return AZ::ComponentTypeList{
-        };
+        return AZ::ComponentTypeList{};
     }
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/LevelModificationToolsModuleInterface.h
+++ b/Gems/LevelModificationTools/Code/Source/LevelModificationToolsModuleInterface.h
@@ -13,8 +13,7 @@
 
 namespace LevelModificationTools
 {
-    class LevelModificationToolsModuleInterface
-        : public AZ::Module
+    class LevelModificationToolsModuleInterface : public AZ::Module
     {
     public:
         AZ_TYPE_INFO_WITH_NAME_DECL(LevelModificationToolsModuleInterface)
@@ -28,4 +27,4 @@ namespace LevelModificationTools
          */
         AZ::ComponentTypeList GetRequiredSystemComponents() const override;
     };
-}// namespace LevelModificationTools
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Tools/LevelModificationToolsEditorModule.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Tools/LevelModificationToolsEditorModule.cpp
@@ -6,13 +6,12 @@
  *
  */
 
+#include "PrefabVariantEditorComponent.h"
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
 #include <LevelModificationToolsModuleInterface.h>
-
 namespace LevelModificationTools
 {
-    class LevelModificationToolsEditorModule
-        : public LevelModificationToolsModuleInterface
+    class LevelModificationToolsEditorModule : public LevelModificationToolsModuleInterface
     {
     public:
         AZ_RTTI(LevelModificationToolsEditorModule, LevelModificationToolsEditorModuleTypeId, LevelModificationToolsModuleInterface);
@@ -22,10 +21,13 @@ namespace LevelModificationTools
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             // Add ALL components descriptors associated with this gem to m_descriptors.
-            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and EditContext.
-            // This happens through the [MyComponent]::Reflect() function.
-            m_descriptors.insert(m_descriptors.end(), {
-            });
+            // This will associate the AzTypeInfo information for the components with the the SerializeContext, BehaviorContext and
+            // EditContext. This happens through the [MyComponent]::Reflect() function.
+            m_descriptors.insert(
+                m_descriptors.end(),
+                {
+                    PrefabVariantEditorComponent::CreateDescriptor(),
+                });
         }
 
         /**
@@ -34,10 +36,9 @@ namespace LevelModificationTools
          */
         AZ::ComponentTypeList GetRequiredSystemComponents() const override
         {
-            return AZ::ComponentTypeList {
-            };
+            return AZ::ComponentTypeList{};
         }
     };
-}// namespace LevelModificationTools
+} // namespace LevelModificationTools
 
 AZ_DECLARE_MODULE_CLASS(Gem_LevelModificationTools, LevelModificationTools::LevelModificationToolsEditorModule)

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
@@ -43,7 +43,7 @@ namespace LevelModificationTools
                     ->UIElement(AZ::Edit::UIHandlers::Button, "Peek", "Peek")
                     ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
                     ->Attribute(AZ::Edit::Attributes::ButtonText, "Peek")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PrefabVariantEditorComponent::TestSpawn);
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PrefabVariantEditorComponent::PreviewVariant);
             }
         }
     }
@@ -84,7 +84,7 @@ namespace LevelModificationTools
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
-    AZ::Crc32 PrefabVariantEditorComponent::TestSpawn()
+    AZ::Crc32 PrefabVariantEditorComponent::PreviewVariant()
     {
         PrefabVariantRequestsBus::Event(m_config.m_groupId, &PrefabVariantRequests::SetPrefabVariant, m_variantToPeek);
         return AZ::Edit::PropertyRefreshLevels::None;

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
@@ -1,0 +1,106 @@
+
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "PrefabVariantEditorComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <Clients/PrefabVariantComponent.h>
+#include <Clients/SpawnPrefab.h>
+namespace LevelModificationTools
+{
+    void PrefabVariantEditorComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PrefabVariantEditorComponent, AZ::Component>()
+                ->Version(1)
+                ->Field("Config", &PrefabVariantEditorComponent::m_config)
+                ->Field("VariantToPeek", &PrefabVariantEditorComponent::m_variantToPeek);
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext
+                    ->Class<PrefabVariantEditorComponent>("Prefab Variant Editor Component", "A component that manages prefab variants.")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->Attribute(AZ::Edit::Attributes::Category, "LevelModificationTools")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantEditorComponent::m_config,
+                        "Config",
+                        "The configuration for the component.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PrefabVariantEditorComponent::OnConfigChanged)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &PrefabVariantEditorComponent::m_variantToPeek,
+                        "Show variant in the Editor",
+                        "The group id of the to take a peek at in the editor.")
+                    ->UIElement(AZ::Edit::UIHandlers::Button, "Peek", "Peek")
+                    ->Attribute(AZ::Edit::Attributes::NameLabelOverride, "")
+                    ->Attribute(AZ::Edit::Attributes::ButtonText, "Peek")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &PrefabVariantEditorComponent::TestSpawn);
+            }
+        }
+    }
+
+    void PrefabVariantEditorComponent::Activate()
+    {
+        LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+        if (m_config.m_defaultPrefabVariant)
+        {
+            m_config.m_defaultPrefabVariant.QueueLoad();
+            m_spawnTicket = SpawnPrefab(m_config.m_defaultPrefabVariant, GetEntityId());
+        }
+    }
+
+    void PrefabVariantEditorComponent::Deactivate()
+    {
+        LevelModificationToolsRequestBus::Handler::BusDisconnect();
+    }
+
+    void PrefabVariantEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)
+    {
+        m_spawnTicket = AzFramework::EntitySpawnTicket();
+        gameEntity->CreateComponent<PrefabVariantComponent>(m_config);
+    }
+
+    AZ::Crc32 PrefabVariantEditorComponent::OnConfigChanged()
+    {
+        if (m_config.m_defaultPrefabVariant)
+        {
+            m_config.m_defaultPrefabVariant.QueueLoad();
+            m_spawnTicket = SpawnPrefab(m_config.m_defaultPrefabVariant, GetEntityId());
+        }
+        if (LevelModificationToolsRequestBus::Handler::BusIsConnected())
+        {
+            LevelModificationToolsRequestBus::Handler::BusDisconnect();
+            LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+        }
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+    AZ::Crc32 PrefabVariantEditorComponent::TestSpawn()
+    {
+        LevelModificationToolsRequestBus::Event(m_config.m_groupId, &LevelModificationToolsRequests::SetPrefabVariant, m_variantToPeek);
+        return AZ::Edit::PropertyRefreshLevels::None;
+    }
+
+    // LevelModificationToolsRequestBus::Handler overrides
+    void PrefabVariantEditorComponent::SetPrefabVariant(AZ::s32 variantId)
+    {
+        const auto assetIter = m_config.m_prefabVariants.find(variantId);
+        AZ_Warning(
+            "PrefabVariantComponent", assetIter != m_config.m_prefabVariants.end(), "Prefab variant with id %d not found.", variantId);
+        if (assetIter != m_config.m_prefabVariants.end())
+        {
+            assetIter->second.QueueLoad();
+            m_spawnTicket = SpawnPrefab(assetIter->second, GetEntityId());
+        }
+    }
+
+} // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.cpp
@@ -50,7 +50,7 @@ namespace LevelModificationTools
 
     void PrefabVariantEditorComponent::Activate()
     {
-        LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+        PrefabVariantRequestsBus::Handler::BusConnect(m_config.m_groupId);
         if (m_config.m_defaultPrefabVariant)
         {
             m_config.m_defaultPrefabVariant.QueueLoad();
@@ -60,7 +60,7 @@ namespace LevelModificationTools
 
     void PrefabVariantEditorComponent::Deactivate()
     {
-        LevelModificationToolsRequestBus::Handler::BusDisconnect();
+        PrefabVariantRequestsBus::Handler::BusDisconnect();
     }
 
     void PrefabVariantEditorComponent::BuildGameEntity(AZ::Entity* gameEntity)
@@ -76,17 +76,17 @@ namespace LevelModificationTools
             m_config.m_defaultPrefabVariant.QueueLoad();
             m_spawnTicket = SpawnPrefab(m_config.m_defaultPrefabVariant, GetEntityId());
         }
-        if (LevelModificationToolsRequestBus::Handler::BusIsConnected())
+        if (PrefabVariantRequestsBus::Handler::BusIsConnected())
         {
-            LevelModificationToolsRequestBus::Handler::BusDisconnect();
-            LevelModificationToolsRequestBus::Handler::BusConnect(m_config.m_groupId);
+            PrefabVariantRequestsBus::Handler::BusDisconnect();
+            PrefabVariantRequestsBus::Handler::BusConnect(m_config.m_groupId);
         }
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
     AZ::Crc32 PrefabVariantEditorComponent::TestSpawn()
     {
-        LevelModificationToolsRequestBus::Event(m_config.m_groupId, &LevelModificationToolsRequests::SetPrefabVariant, m_variantToPeek);
+        PrefabVariantRequestsBus::Event(m_config.m_groupId, &PrefabVariantRequests::SetPrefabVariant, m_variantToPeek);
         return AZ::Edit::PropertyRefreshLevels::None;
     }
 

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
@@ -8,37 +8,42 @@
 
 #pragma once
 
-#include <AzCore/Component/Component.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
-#include "PrefabVariantConfig.h"
+#include <Clients/PrefabVariantConfig.h>
 #include <LevelModificationTools/LevelModificationToolsBus.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
 
 namespace LevelModificationTools
 {
-    class PrefabVariantComponent
-        : public AZ::Component
+    class PrefabVariantEditorComponent
+        : public AzToolsFramework::Components::EditorComponentBase
         , private LevelModificationToolsRequestBus::Handler
     {
     public:
-        AZ_COMPONENT(PrefabVariantComponent, "{018f8611-85fc-7e0f-a879-b3a0ff793535}", AZ::Component);
-        PrefabVariantComponent() = default;
-        PrefabVariantComponent(const PrefabVariantConfig& config);
-        ~PrefabVariantComponent() override = default;
+        AZ_EDITOR_COMPONENT(PrefabVariantEditorComponent, "{018f8675-2a33-7855-a242-a45e6ec7fd4b}");
+        PrefabVariantEditorComponent() = default;
+        ~PrefabVariantEditorComponent() override = default;
 
         // Component overrides
         void Activate() override;
         void Deactivate() override;
 
+        // AzToolsFramework::Components::EditorComponentBase overrides
+        void BuildGameEntity(AZ::Entity* gameEntity) override;
+
         static void Reflect(AZ::ReflectContext* context);
 
     private:
+        AZ::Crc32 OnConfigChanged();
+        AZ::Crc32 TestSpawn();
         // LevelModificationToolsRequestBus::Handler overrides
         void SetPrefabVariant(AZ::s32 variantId) override;
 
         AzFramework::EntitySpawnTicket m_spawnTicket; //! Currently spawned ticket
         PrefabVariantConfig m_config; //! Configuration for the component
+        AZ::s32 m_variantToPeek = 0; //! The group id of the to take a peek at in the editor
     };
 } // namespace LevelModificationTools

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
@@ -38,7 +38,7 @@ namespace LevelModificationTools
 
     private:
         AZ::Crc32 OnConfigChanged();
-        AZ::Crc32 TestSpawn();
+        AZ::Crc32 PreviewVariant();
         // LevelModificationToolsRequestBus::Handler overrides
         void SetPrefabVariant(AZ::s32 variantId) override;
 

--- a/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
+++ b/Gems/LevelModificationTools/Code/Source/Tools/PrefabVariantEditorComponent.h
@@ -13,14 +13,14 @@
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 #include <Clients/PrefabVariantConfig.h>
-#include <LevelModificationTools/LevelModificationToolsBus.h>
 #include <LevelModificationTools/LevelModificationToolsTypeIds.h>
+#include <LevelModificationTools/PrefabVariantRequestsBus.h>
 
 namespace LevelModificationTools
 {
     class PrefabVariantEditorComponent
         : public AzToolsFramework::Components::EditorComponentBase
-        , private LevelModificationToolsRequestBus::Handler
+        , private PrefabVariantRequestsBus::Handler
     {
     public:
         AZ_EDITOR_COMPONENT(PrefabVariantEditorComponent, "{018f8675-2a33-7855-a242-a45e6ec7fd4b}");

--- a/Gems/LevelModificationTools/Code/levelmodificationtools_api_files.cmake
+++ b/Gems/LevelModificationTools/Code/levelmodificationtools_api_files.cmake
@@ -5,6 +5,6 @@
 #
 
 set(FILES
-    Include/LevelModificationTools/LevelModificationToolsBus.h
+    Include/LevelModificationTools/PrefabVariantRequestsBus.h
     Include/LevelModificationTools/LevelModificationToolsTypeIds.h
 )

--- a/Gems/LevelModificationTools/Code/levelmodificationtools_editor_private_files.cmake
+++ b/Gems/LevelModificationTools/Code/levelmodificationtools_editor_private_files.cmake
@@ -5,4 +5,6 @@
 #
 
 set(FILES
+    Source/Tools/PrefabVariantEditorComponent.cpp
+    Source/Tools/PrefabVariantEditorComponent.h
 )

--- a/Gems/LevelModificationTools/Code/levelmodificationtools_private_files.cmake
+++ b/Gems/LevelModificationTools/Code/levelmodificationtools_private_files.cmake
@@ -11,4 +11,6 @@ set(FILES
     Source/Clients/PrefabVariantComponent.h
     Source/Clients/LevelModificationToolsBus.cpp
     Source/Clients/PrefabVariantConfig.cpp
+    Source/Clients/SpawnPrefab.cpp
+    Source/Clients/SpawnPrefab.h
 )

--- a/Gems/LevelModificationTools/Code/levelmodificationtools_private_files.cmake
+++ b/Gems/LevelModificationTools/Code/levelmodificationtools_private_files.cmake
@@ -7,4 +7,8 @@
 set(FILES
     Source/LevelModificationToolsModuleInterface.cpp
     Source/LevelModificationToolsModuleInterface.h
+    Source/Clients/PrefabVariantComponent.cpp
+    Source/Clients/PrefabVariantComponent.h
+    Source/Clients/LevelModificationToolsBus.cpp
+    Source/Clients/PrefabVariantConfig.cpp
 )


### PR DESCRIPTION
# LevelModificationTools
Tool that allows to change level's content during game via scripts or buses. It allows to test behavior in Editor.

## PrefabVariantComponent
PrefabVariantComponent allows to choose a variant of the object during simulation using scripting. A good example is replacing a tree spiece for an orchard. The variant of the object should be contained as O3DE prefab. The list of variants is configured with a map reflected in the component. The Group ID allows to have multiple entries that will change variants together.

![PrefabVariantComponent](https://github.com/RobotecAI/robotec-o3de-tools/assets/3209244/b551b190-2792-43ba-8e54-83eaff39d555)


The default prefab variant can be set - the chosen prefab will be loaded automatically on component activation.
The Peek button allows the level designer to take a look at a given variant, without need to start simulation. It will affect all components with the same Group ID. The Prefab Editor Component handles a PrefabVariantRequestsBus. This bus has a method SetPrefabVariant that allows to change of a variant. The key to this bus is the above-mentioned Group ID.