### PR TITLE
use topic in ROS2 SubscriberNotificationsBus

### DIFF
--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
@@ -91,9 +91,9 @@ namespace ROS2ScriptIntegration
         using TypeName = std_msgs::msg::Bool;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnStdMsgBool, msg.data);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgBool, msg.data);
             });
     }
 
@@ -102,12 +102,13 @@ namespace ROS2ScriptIntegration
         using TypeName = sensor_msgs::msg::Joy;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
                 TypeName cmsg{ msg };
                 cmsg.buttons.resize(4);
                 cmsg.axes.resize(4);
-                SubscriberNotificationsBus::Broadcast(
+                SubscriberNotificationsBus::Event(
+                    topicName,
                     &SubscriberNotificationsBus::Events::OnSensorMsgJoy,
                     cmsg.buttons[0],
                     cmsg.buttons[1],
@@ -125,7 +126,7 @@ namespace ROS2ScriptIntegration
         using TypeName = geometry_msgs::msg::PoseStamped;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
                 const auto& position = msg.pose.position;
                 const auto& orientation = msg.pose.orientation;
@@ -133,7 +134,8 @@ namespace ROS2ScriptIntegration
                     AZ::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w),
                     AZ::Vector3(position.x, position.y, position.z));
                 const AZStd::string frameId(msg.header.frame_id.c_str());
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnGeometryMsgPoseStamped, frameId, transform);
+                SubscriberNotificationsBus::Event(
+                    topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgPoseStamped, frameId, transform);
             });
     }
 
@@ -142,10 +144,10 @@ namespace ROS2ScriptIntegration
         using TypeName = std_msgs::msg::String;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
                 const AZStd::string str(msg.data.c_str());
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnStdMsgString, str);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgString, str);
             });
     }
 
@@ -154,9 +156,9 @@ namespace ROS2ScriptIntegration
         using TypeName = std_msgs::msg::Float32;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnStdMsgFloat32, msg.data);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgFloat32, msg.data);
             });
     }
 
@@ -165,9 +167,9 @@ namespace ROS2ScriptIntegration
         using TypeName = std_msgs::msg::UInt32;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
             });
     };
 
@@ -176,9 +178,9 @@ namespace ROS2ScriptIntegration
         using TypeName = std_msgs::msg::Int32;
         SubscribeToTopic<TypeName>(
             topicName,
-            [](const TypeName& msg)
+            [topicName](const TypeName& msg)
             {
-                SubscriberNotificationsBus::Broadcast(&SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
             });
     };
 

--- a/Gems/ROS2ScriptIntegration/README.md
+++ b/Gems/ROS2ScriptIntegration/README.md
@@ -72,7 +72,7 @@ Similar to _ScriptCanvas_ example, receiving a message via ROS 2 topic requires 
 Please find the code snippet below, in which the subscription happens in the class activation and the handler is implemented as a method override.
 ```lua
 function myscript:OnActivate()
-	self.ros2BusHandler = SubscriberNotificationsBus.Connect(self, 0)
+	self.ros2BusHandler = SubscriberNotificationsBus.Connect(self, /input)
 	SubscriberRequestBus.Broadcast.SubscribeToString("/input")
 end
 


### PR DESCRIPTION
The previous code was subscribing to all possible topics, now it connects to one topic only.

Tested with LUA and SC:
![image](https://github.com/RobotecAI/robotec-o3de-tools/assets/134940295/83d3158c-0f5a-4a2f-aeac-029e4b2c3bf0)
