### PR TITLE
Automated disabling of physics therefore making it working-ish

### DIFF
--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.h
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.h
@@ -72,6 +72,9 @@ namespace ROS2PoseControl
 
         void ApplyTransform(const AZ::Transform& transform);
 
+        void DisablePhysics();
+        bool m_isPhysicsDisabled = false;
+
         bool m_isTracking = false;
         ROS2PoseControlConfiguration m_configuration;
 


### PR DESCRIPTION
response to https://github.com/RobotecAI/robotec-o3de-tools/issues/32

Now component automatically makes sure physics are disabled in entity and it's children, it was put in the apply transform to make to avoid issues with concurrency as putting it in Activate or AZ::TickBus::QueueFunction produced glitches 