### PR TITLE
Removed cursor visibility in game mode

### DIFF
--- a/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
+++ b/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
@@ -29,10 +29,6 @@ namespace RobotecSpectatorCamera
         RobotecSpectatorCameraRequestBus::Handler::BusConnect(GetEntityId());
         AZ::TickBus::Handler::BusConnect();
         AzFramework::InputChannelEventListener::Connect();
-        AzFramework::InputSystemCursorRequestBus::Event(
-            AzFramework::InputDeviceMouse::Id,
-            &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
-            AzFramework::SystemCursorState::ConstrainedAndHidden);
 
         AZ::TransformBus::EventResult(m_currentTransform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
     }
@@ -119,6 +115,10 @@ namespace RobotecSpectatorCamera
                 // Capture the initial mouse position and cursor state
                 m_initialMousePosition = GetCurrentMousePosition();
                 m_ignoreNextMovement = true; // Flag to ignore the next mouse movement preventing jump on re-centering
+                AzFramework::InputSystemCursorRequestBus::Event(
+                    AzFramework::InputDeviceMouse::Id,
+                    &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
+                    AzFramework::SystemCursorState::ConstrainedAndHidden);
             }
             else if (inputChannel.IsStateEnded())
             {
@@ -132,6 +132,10 @@ namespace RobotecSpectatorCamera
 
                 // Update m_lastMousePosition to the restored position to prevent the jump on the next rotation start
                 m_lastMousePosition = m_initialMousePosition;
+                AzFramework::InputSystemCursorRequestBus::Event(
+                    AzFramework::InputDeviceMouse::Id,
+                    &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
+                    AzFramework::SystemCursorState::ConstrainedAndVisible);
             }
         }
 


### PR DESCRIPTION
How cursor changes its visibility:
- in ThirdPerson - cursor is hidden when RMB is pressed
- in FreeFlying - cursor is hidden when user uses mouse to look around

This change is added to remove annoying cursor's jumps to the center of the screen.