### PR TITLE
Revert "[Pointcloud] Add Support for clouds without color #47"

### DIFF
--- a/Gems/Pointcloud/Code/Source/Tools/Builders/PointcloudBuilder.cpp
+++ b/Gems/Pointcloud/Code/Source/Tools/Builders/PointcloudBuilder.cpp
@@ -82,21 +82,9 @@ namespace Pointcloud
     {
         response.m_resultCode = AssetBuilderSDK::ProcessJobResult_Failed;
         happly::PLYData plyIn(request.m_fullPath.c_str());
-        const auto elementNames = plyIn.getElementNames();
         auto vertices = plyIn.getVertexPositions();
-        bool hasRed = std::find(elementNames.begin(), elementNames.end(), "red") != elementNames.end();
-        bool hasGreen = std::find(elementNames.begin(), elementNames.end(), "green") != elementNames.end();
-        bool hasBlue = std::find(elementNames.begin(), elementNames.end(), "blue") != elementNames.end();
-        std::vector<std::array<unsigned char, 3>> colors;
-        if (hasRed && hasGreen && hasBlue)
-        {
-            colors = plyIn.getVertexColors();
-        }
-        else
-        {
-            AZ_TracePrintf(AssetBuilderSDK::WarningWindow, "Warning: The ply file does not contain red, green, and blue color data.\n");
-            colors.resize(vertices.size(), { 255, 255, 255 });
-        }
+        auto colors = plyIn.getVertexColors();
+        const auto elementNames = plyIn.getElementNames();
 
         AZ::Data::Asset<PointcloudAsset> pointcloudAsset;
         pointcloudAsset.Create(AZ::Data::AssetId(AZ::Uuid::CreateRandom()));


### PR DESCRIPTION
Reverts RobotecAI/robotec-o3de-tools#51 This has a bug in the logic. Pointclouds with correct colors lost them after reprocessing