### PR TITLE
Update ROS2ScriptIntegration

### DIFF
--- a/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
+++ b/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
@@ -34,11 +34,12 @@ namespace ROS2ScriptIntegration
         virtual void SubscribeToStdMsgBool(const AZStd::string& topicName) = 0;
         virtual void SubscribeToSensorMsgJoy(const AZStd::string& topicName) = 0;
         virtual void SubscribeToGeometryMsgPoseStamped(const AZStd::string& topicName) = 0;
-        virtual void SubscribeToString(const AZStd::string& topicName) = 0;
-        virtual void SubscribeToFloat32(const AZStd::string& topicName) = 0;
-        virtual void SubscribeToUInt32(const AZStd::string& topicName) = 0;
-        virtual void SubscribeToInt32(const AZStd::string& topicName) = 0;
-        virtual void SubscribeToVector3(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToStdMsgString(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToStdMsgFloat32(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToStdMsgUInt32(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToStdMsgInt32(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToGeometryMsgVector3(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToGeometryMsgQuaternion(const AZStd::string& topicName) = 0;
 
         static void Reflect(AZ::ReflectContext* context);
     };
@@ -62,6 +63,7 @@ namespace ROS2ScriptIntegration
         virtual void OnStdMsgUInt32(const uint32_t value) = 0;
         virtual void OnStdMsgInt32(const int32_t value) = 0;
         virtual void OnGeometryMsgVector3(const AZ::Vector3& value) = 0;
+        virtual void OnGeometryMsgQuaternion(const AZ::Quaternion& value) = 0;
     };
 
     using SubscriberNotificationsBus = AZ::EBus<SubscriberNotifications>;
@@ -82,7 +84,8 @@ namespace ROS2ScriptIntegration
             OnStdMsgFloat32,
             OnStdMsgUInt32,
             OnStdMsgInt32,
-            OnGeometryMsgVector3);
+            OnGeometryMsgVector3,
+            OnGeometryMsgQuaternion);
 
         void OnStdMsgBool(bool value) override;
         void OnSensorMsgJoy(bool b0, bool b1, bool b2, bool b3, float f0, float f1, float f2, float f3) override;
@@ -92,6 +95,7 @@ namespace ROS2ScriptIntegration
         void OnStdMsgUInt32(const uint32_t value) override;
         void OnStdMsgInt32(const int32_t value) override;
         void OnGeometryMsgVector3(const AZ::Vector3& value) override;
+        void OnGeometryMsgQuaternion(const AZ::Quaternion& value) override;
 
         static void Reflect(AZ::ReflectContext* context);
     };

--- a/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
+++ b/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
@@ -40,6 +40,7 @@ namespace ROS2ScriptIntegration
         virtual void SubscribeToStdMsgInt32(const AZStd::string& topicName) = 0;
         virtual void SubscribeToGeometryMsgVector3(const AZStd::string& topicName) = 0;
         virtual void SubscribeToGeometryMsgQuaternion(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToGeometryMsgTransform(const AZStd::string& topicName) = 0;
 
         static void Reflect(AZ::ReflectContext* context);
     };
@@ -64,6 +65,7 @@ namespace ROS2ScriptIntegration
         virtual void OnStdMsgInt32(const int32_t value) = 0;
         virtual void OnGeometryMsgVector3(const AZ::Vector3& value) = 0;
         virtual void OnGeometryMsgQuaternion(const AZ::Quaternion& value) = 0;
+        virtual void OnGeometryMsgTransform(const AZ::Transform& value) = 0;
     };
 
     using SubscriberNotificationsBus = AZ::EBus<SubscriberNotifications>;
@@ -85,7 +87,8 @@ namespace ROS2ScriptIntegration
             OnStdMsgUInt32,
             OnStdMsgInt32,
             OnGeometryMsgVector3,
-            OnGeometryMsgQuaternion);
+            OnGeometryMsgQuaternion,
+            OnGeometryMsgTransform);
 
         void OnStdMsgBool(bool value) override;
         void OnSensorMsgJoy(bool b0, bool b1, bool b2, bool b3, float f0, float f1, float f2, float f3) override;
@@ -96,6 +99,7 @@ namespace ROS2ScriptIntegration
         void OnStdMsgInt32(const int32_t value) override;
         void OnGeometryMsgVector3(const AZ::Vector3& value) override;
         void OnGeometryMsgQuaternion(const AZ::Quaternion& value) override;
+        void OnGeometryMsgTransform(const AZ::Transform& value) override;
 
         static void Reflect(AZ::ReflectContext* context);
     };

--- a/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
+++ b/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptSubscriberBus.h
@@ -38,6 +38,7 @@ namespace ROS2ScriptIntegration
         virtual void SubscribeToFloat32(const AZStd::string& topicName) = 0;
         virtual void SubscribeToUInt32(const AZStd::string& topicName) = 0;
         virtual void SubscribeToInt32(const AZStd::string& topicName) = 0;
+        virtual void SubscribeToVector3(const AZStd::string& topicName) = 0;
 
         static void Reflect(AZ::ReflectContext* context);
     };
@@ -60,6 +61,7 @@ namespace ROS2ScriptIntegration
         virtual void OnStdMsgFloat32(const float value) = 0;
         virtual void OnStdMsgUInt32(const uint32_t value) = 0;
         virtual void OnStdMsgInt32(const int32_t value) = 0;
+        virtual void OnGeometryMsgVector3(const AZ::Vector3& value) = 0;
     };
 
     using SubscriberNotificationsBus = AZ::EBus<SubscriberNotifications>;
@@ -79,7 +81,8 @@ namespace ROS2ScriptIntegration
             OnStdMsgString,
             OnStdMsgFloat32,
             OnStdMsgUInt32,
-            OnStdMsgInt32);
+            OnStdMsgInt32,
+            OnGeometryMsgVector3);
 
         void OnStdMsgBool(bool value) override;
         void OnSensorMsgJoy(bool b0, bool b1, bool b2, bool b3, float f0, float f1, float f2, float f3) override;
@@ -88,6 +91,7 @@ namespace ROS2ScriptIntegration
         void OnStdMsgFloat32(const float value) override;
         void OnStdMsgUInt32(const uint32_t value) override;
         void OnStdMsgInt32(const int32_t value) override;
+        void OnGeometryMsgVector3(const AZ::Vector3& value) override;
 
         static void Reflect(AZ::ReflectContext* context);
     };

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
@@ -46,6 +46,11 @@ namespace ROS2ScriptIntegration
         Call(FN_OnGeometryMsgVector3, value);
     }
 
+    void SubscriberNotificationHandler::OnGeometryMsgQuaternion(const AZ::Quaternion& value)
+    {
+        Call(FN_OnGeometryMsgQuaternion, value);
+    }
+
     void SubscriberNotificationHandler::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
@@ -60,11 +65,16 @@ namespace ROS2ScriptIntegration
                     "SubscribeToGeometryMsgPoseStamped",
                     &SubscriberRequestBus::Events::SubscribeToGeometryMsgPoseStamped,
                     { { { "Topic", "" } } })
-                ->Event("SubscribeToString", &SubscriberRequestBus::Events::SubscribeToString, { { { "Topic", "" } } })
-                ->Event("SubscribeToFloat32", &SubscriberRequestBus::Events::SubscribeToFloat32, { { { "Topic", "" } } })
-                ->Event("SubscribeToUInt32", &SubscriberRequestBus::Events::SubscribeToUInt32, { { { "Topic", "" } } })
-                ->Event("SubscribeToInt32", &SubscriberRequestBus::Events::SubscribeToInt32, { { { "Topic", "" } } })
-                ->Event("SubscribeToVector3", &SubscriberRequestBus::Events::SubscribeToVector3, { { { "Topic", "" } } });
+                ->Event("SubscribeToStdMsgString", &SubscriberRequestBus::Events::SubscribeToStdMsgString, { { { "Topic", "" } } })
+                ->Event("SubscribeToStdMsgFloat32", &SubscriberRequestBus::Events::SubscribeToStdMsgFloat32, { { { "Topic", "" } } })
+                ->Event("SubscribeToStdMsgUInt32", &SubscriberRequestBus::Events::SubscribeToStdMsgUInt32, { { { "Topic", "" } } })
+                ->Event("SubscribeToStdMsgInt32", &SubscriberRequestBus::Events::SubscribeToStdMsgInt32, { { { "Topic", "" } } })
+                ->Event(
+                    "SubscribeToGeometryMsgVector3", &SubscriberRequestBus::Events::SubscribeToGeometryMsgVector3, { { { "Topic", "" } } })
+                ->Event(
+                    "SubscribeToGeometryMsgQuaternion",
+                    &SubscriberRequestBus::Events::SubscribeToGeometryMsgQuaternion,
+                    { { { "Topic", "" } } });
         }
     }
 
@@ -94,7 +104,8 @@ namespace ROS2ScriptIntegration
                 ->Event("OnStdMsgFloat32", &SubscriberNotificationsBus::Events::OnStdMsgFloat32)
                 ->Event("OnStdMsgUInt32", &SubscriberNotificationsBus::Events::OnStdMsgUInt32)
                 ->Event("OnStdMsgInt32", &SubscriberNotificationsBus::Events::OnStdMsgInt32)
-                ->Event("OnGeometryMsgVector3", &SubscriberNotificationsBus::Events::OnGeometryMsgVector3);
+                ->Event("OnGeometryMsgVector3", &SubscriberNotificationsBus::Events::OnGeometryMsgVector3)
+                ->Event("OnGeometryMsgQuaternion", &SubscriberNotificationsBus::Events::OnGeometryMsgQuaternion);
         }
     }
 } // namespace ROS2ScriptIntegration

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
@@ -51,6 +51,11 @@ namespace ROS2ScriptIntegration
         Call(FN_OnGeometryMsgQuaternion, value);
     }
 
+    void SubscriberNotificationHandler::OnGeometryMsgTransform(const AZ::Transform& value)
+    {
+        Call(FN_OnGeometryMsgTransform, value);
+    }
+
     void SubscriberNotificationHandler::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
@@ -74,6 +79,10 @@ namespace ROS2ScriptIntegration
                 ->Event(
                     "SubscribeToGeometryMsgQuaternion",
                     &SubscriberRequestBus::Events::SubscribeToGeometryMsgQuaternion,
+                    { { { "Topic", "" } } })
+                ->Event(
+                    "SubscribeToGeometryMsgTransform",
+                    &SubscriberRequestBus::Events::SubscribeToGeometryMsgTransform,
                     { { { "Topic", "" } } });
         }
     }
@@ -105,7 +114,8 @@ namespace ROS2ScriptIntegration
                 ->Event("OnStdMsgUInt32", &SubscriberNotificationsBus::Events::OnStdMsgUInt32)
                 ->Event("OnStdMsgInt32", &SubscriberNotificationsBus::Events::OnStdMsgInt32)
                 ->Event("OnGeometryMsgVector3", &SubscriberNotificationsBus::Events::OnGeometryMsgVector3)
-                ->Event("OnGeometryMsgQuaternion", &SubscriberNotificationsBus::Events::OnGeometryMsgQuaternion);
+                ->Event("OnGeometryMsgQuaternion", &SubscriberNotificationsBus::Events::OnGeometryMsgQuaternion)
+                ->Event("OnGeometryMsgTransform", &SubscriberNotificationsBus::Events::OnGeometryMsgTransform);
         }
     }
 } // namespace ROS2ScriptIntegration

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptSubscriberBus.cpp
@@ -41,6 +41,11 @@ namespace ROS2ScriptIntegration
         Call(FN_OnStdMsgInt32, value);
     }
 
+    void SubscriberNotificationHandler::OnGeometryMsgVector3(const AZ::Vector3& value)
+    {
+        Call(FN_OnGeometryMsgVector3, value);
+    }
+
     void SubscriberNotificationHandler::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
@@ -58,7 +63,8 @@ namespace ROS2ScriptIntegration
                 ->Event("SubscribeToString", &SubscriberRequestBus::Events::SubscribeToString, { { { "Topic", "" } } })
                 ->Event("SubscribeToFloat32", &SubscriberRequestBus::Events::SubscribeToFloat32, { { { "Topic", "" } } })
                 ->Event("SubscribeToUInt32", &SubscriberRequestBus::Events::SubscribeToUInt32, { { { "Topic", "" } } })
-                ->Event("SubscribeToInt32", &SubscriberRequestBus::Events::SubscribeToInt32, { { { "Topic", "" } } });
+                ->Event("SubscribeToInt32", &SubscriberRequestBus::Events::SubscribeToInt32, { { { "Topic", "" } } })
+                ->Event("SubscribeToVector3", &SubscriberRequestBus::Events::SubscribeToVector3, { { { "Topic", "" } } });
         }
     }
 
@@ -87,7 +93,8 @@ namespace ROS2ScriptIntegration
                 ->Event("OnStdMsgString", &SubscriberNotificationsBus::Events::OnStdMsgString)
                 ->Event("OnStdMsgFloat32", &SubscriberNotificationsBus::Events::OnStdMsgFloat32)
                 ->Event("OnStdMsgUInt32", &SubscriberNotificationsBus::Events::OnStdMsgUInt32)
-                ->Event("OnStdMsgInt32", &SubscriberNotificationsBus::Events::OnStdMsgInt32);
+                ->Event("OnStdMsgInt32", &SubscriberNotificationsBus::Events::OnStdMsgInt32)
+                ->Event("OnGeometryMsgVector3", &SubscriberNotificationsBus::Events::OnGeometryMsgVector3);
         }
     }
 } // namespace ROS2ScriptIntegration

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
@@ -208,6 +208,22 @@ namespace ROS2ScriptIntegration
             });
     }
 
+    void SubscriberSystemComponent::SubscribeToGeometryMsgTransform(const AZStd::string& topicName)
+    {
+        using TypeName = geometry_msgs::msg::Transform;
+        SubscribeToTopic<TypeName>(
+            topicName,
+            [topicName](const TypeName& msg)
+            {
+                const auto& position = msg.translation;
+                const auto& orientation = msg.rotation;
+                const auto data = AZ::Transform::CreateFromQuaternionAndTranslation(
+                    AZ::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w),
+                    AZ::Vector3(position.x, position.y, position.z));
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgTransform, data);
+            });
+    }
+
     template<typename MessageType>
     void SubscriberSystemComponent::SubscribeToTopic(
         const AZStd::string& topicName, const std::function<void(const MessageType&)>& callback)

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
@@ -169,7 +169,7 @@ namespace ROS2ScriptIntegration
             topicName,
             [topicName](const TypeName& msg)
             {
-                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgUInt32, msg.data);
             });
     };
 
@@ -183,6 +183,18 @@ namespace ROS2ScriptIntegration
                 SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnStdMsgInt32, msg.data);
             });
     };
+
+    void SubscriberSystemComponent::SubscribeToVector3(const AZStd::string& topicName)
+    {
+        using TypeName = geometry_msgs::msg::Vector3;
+        SubscribeToTopic<TypeName>(
+            topicName,
+            [topicName](const TypeName& msg)
+            {
+                const auto vector3 = AZ::Vector3(msg.x, msg.y, msg.z);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgVector3, vector3);
+            });
+    }
 
     template<typename MessageType>
     void SubscriberSystemComponent::SubscribeToTopic(

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.cpp
@@ -139,7 +139,7 @@ namespace ROS2ScriptIntegration
             });
     }
 
-    void SubscriberSystemComponent::SubscribeToString(const AZStd::string& topicName)
+    void SubscriberSystemComponent::SubscribeToStdMsgString(const AZStd::string& topicName)
     {
         using TypeName = std_msgs::msg::String;
         SubscribeToTopic<TypeName>(
@@ -151,7 +151,7 @@ namespace ROS2ScriptIntegration
             });
     }
 
-    void SubscriberSystemComponent::SubscribeToFloat32(const AZStd::string& topicName)
+    void SubscriberSystemComponent::SubscribeToStdMsgFloat32(const AZStd::string& topicName)
     {
         using TypeName = std_msgs::msg::Float32;
         SubscribeToTopic<TypeName>(
@@ -162,7 +162,7 @@ namespace ROS2ScriptIntegration
             });
     }
 
-    void SubscriberSystemComponent::SubscribeToUInt32(const AZStd::string& topicName)
+    void SubscriberSystemComponent::SubscribeToStdMsgUInt32(const AZStd::string& topicName)
     {
         using TypeName = std_msgs::msg::UInt32;
         SubscribeToTopic<TypeName>(
@@ -173,7 +173,7 @@ namespace ROS2ScriptIntegration
             });
     };
 
-    void SubscriberSystemComponent::SubscribeToInt32(const AZStd::string& topicName)
+    void SubscriberSystemComponent::SubscribeToStdMsgInt32(const AZStd::string& topicName)
     {
         using TypeName = std_msgs::msg::Int32;
         SubscribeToTopic<TypeName>(
@@ -184,15 +184,27 @@ namespace ROS2ScriptIntegration
             });
     };
 
-    void SubscriberSystemComponent::SubscribeToVector3(const AZStd::string& topicName)
+    void SubscriberSystemComponent::SubscribeToGeometryMsgVector3(const AZStd::string& topicName)
     {
         using TypeName = geometry_msgs::msg::Vector3;
         SubscribeToTopic<TypeName>(
             topicName,
             [topicName](const TypeName& msg)
             {
-                const auto vector3 = AZ::Vector3(msg.x, msg.y, msg.z);
-                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgVector3, vector3);
+                const auto data = AZ::Vector3(msg.x, msg.y, msg.z);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgVector3, data);
+            });
+    }
+
+    void SubscriberSystemComponent::SubscribeToGeometryMsgQuaternion(const AZStd::string& topicName)
+    {
+        using TypeName = geometry_msgs::msg::Quaternion;
+        SubscribeToTopic<TypeName>(
+            topicName,
+            [topicName](const TypeName& msg)
+            {
+                const auto data = AZ::Quaternion(msg.x, msg.y, msg.z, msg.w);
+                SubscriberNotificationsBus::Event(topicName, &SubscriberNotificationsBus::Events::OnGeometryMsgQuaternion, data);
             });
     }
 

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
@@ -41,11 +41,12 @@ namespace ROS2ScriptIntegration
         void SubscribeToStdMsgBool(const AZStd::string& topicName) override;
         void SubscribeToSensorMsgJoy(const AZStd::string& topicName) override;
         void SubscribeToGeometryMsgPoseStamped(const AZStd::string& topicName) override;
-        void SubscribeToString(const AZStd::string& topicName) override;
-        void SubscribeToFloat32(const AZStd::string& topicName) override;
-        void SubscribeToUInt32(const AZStd::string& topicName) override;
-        void SubscribeToInt32(const AZStd::string& topicName) override;
-        void SubscribeToVector3(const AZStd::string& topicName) override;
+        void SubscribeToStdMsgString(const AZStd::string& topicName) override;
+        void SubscribeToStdMsgFloat32(const AZStd::string& topicName) override;
+        void SubscribeToStdMsgUInt32(const AZStd::string& topicName) override;
+        void SubscribeToStdMsgInt32(const AZStd::string& topicName) override;
+        void SubscribeToGeometryMsgVector3(const AZStd::string& topicName) override;
+        void SubscribeToGeometryMsgQuaternion(const AZStd::string& topicName) override;
 
         // AZ::Component overrides ...
         void Init() override;

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
@@ -45,6 +45,7 @@ namespace ROS2ScriptIntegration
         void SubscribeToFloat32(const AZStd::string& topicName) override;
         void SubscribeToUInt32(const AZStd::string& topicName) override;
         void SubscribeToInt32(const AZStd::string& topicName) override;
+        void SubscribeToVector3(const AZStd::string& topicName) override;
 
         // AZ::Component overrides ...
         void Init() override;

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/SubscriberSystemComponent.h
@@ -47,6 +47,7 @@ namespace ROS2ScriptIntegration
         void SubscribeToStdMsgInt32(const AZStd::string& topicName) override;
         void SubscribeToGeometryMsgVector3(const AZStd::string& topicName) override;
         void SubscribeToGeometryMsgQuaternion(const AZStd::string& topicName) override;
+        void SubscribeToGeometryMsgTransform(const AZStd::string& topicName) override;
 
         // AZ::Component overrides ...
         void Init() override;

--- a/Gems/ROS2ScriptIntegration/README.md
+++ b/Gems/ROS2ScriptIntegration/README.md
@@ -53,7 +53,7 @@ Let us subscribe to the string message topic from ROS 2.
 
 **Explanation:**
 The "OnGraphStart" node is called on the component being activated. 
-It activates a 'SubscribeToString` node, which triggers the subscription to a topic with the given name.
+It activates a 'SubscribeToStdMsgString` node, which triggers the subscription to a topic with the given name.
 Next, the Event Handler for `SubscriberNotificationBus` is activated. It generates a pulse and exposes received data on its input.
 
 To send a message to the ROS 2 system copy the following line to the terminal:
@@ -73,7 +73,7 @@ Please find the code snippet below, in which the subscription happens in the cla
 ```lua
 function myscript:OnActivate()
 	self.ros2BusHandler = SubscriberNotificationsBus.Connect(self, /input)
-	SubscriberRequestBus.Broadcast.SubscribeToString("/input")
+	SubscriberRequestBus.Broadcast.SubscribeToStdMsgString("/input")
 end
 
 function myscript:OnStdMsgString(message)


### PR DESCRIPTION
Few updates in `ROS2ScriptIntegration` Gem:
- fix int/uint bug
- unify names to use message type prefix (`SubscribeToString` -> `SubscribeToStdMsgString`) - it was sometimes added, sometimes not
- add `Vector3`, `Quaternion`, and `Transform` support in the subscribers (it was already added to publishers)

Tested with the script
```lua
local test_bus = { 
    Properties = 
    {
    },
    topicVector3 = "test/vector3",
    topicQuaternion = "test/quaternion",
    topicTransform = "test/transform"
}

function test_bus:OnActivate()
	self.ros2TestVector3BusHandler = SubscriberNotificationsBus.Connect(self, self.topicVector3)
	SubscriberRequestBus.Broadcast.SubscribeToGeometryMsgVector3(self.topicVector3)

    self.ros2TestQuaternionBusHandler = SubscriberNotificationsBus.Connect(self, self.topicQuaternion)
	SubscriberRequestBus.Broadcast.SubscribeToGeometryMsgQuaternion(self.topicQuaternion)

    self.ros2TestTransformBusHandler = SubscriberNotificationsBus.Connect(self, self.topicTransform)
	SubscriberRequestBus.Broadcast.SubscribeToGeometryMsgTransform(self.topicTransform)
end

function test_bus:OnDeactivate()
	if self.ros2TestVector3BusHandler ~= nil then
		self.ros2TestVector3BusHandler:Disconnect()
	end

    if self.ros2TestQuaternionBusHandler ~= nil then
		self.ros2TestQuaternionBusHandler:Disconnect()
	end

    if self.ros2TestTransformBusHandler ~= nil then
		self.ros2TestTransformBusHandler:Disconnect()
	end
end

function test_bus:OnGeometryMsgVector3(value)
    Debug.Log("Received vector value x: " .. value.x)
    Debug.Log("Received vector value y: " .. value.y)
    Debug.Log("Received vector value z: " .. value.z)
end

function test_bus:OnGeometryMsgQuaternion(value)
    Debug.Log("Received quaternion value x: " .. value.x)
    Debug.Log("Received quaternion value y: " .. value.y)
    Debug.Log("Received quaternion value z: " .. value.z)
    Debug.Log("Received quaternion value w: " .. value.w)
end

function test_bus:OnGeometryMsgTransform(value)
    Debug.Log("Received transform translation value x: " .. value.translation.x)
    Debug.Log("Received transform translation value y: " .. value.translation.y)
    Debug.Log("Received transform translation value z: " .. value.translation.z)

    Debug.Log("Received transform rotation value x: " .. value.rotation.x)
    Debug.Log("Received transform rotation value y: " .. value.rotation.y)
    Debug.Log("Received transform rotation value z: " .. value.rotation.z)
    Debug.Log("Received transform rotation value w: " .. value.rotation.w)
end

return test_bus
```

ros 2 calls:
```
ros2 topic pub --once /test/quaternion geometry_msgs/msg/Quaternion "{x: 2.0, y: 3.0, z: 4.0, w: 1.0}"
ros2 topic pub --once /test/vector3 geometry_msgs/msg/Vector3 "{x: 1, y: 2, z: 3}"
ros2 topic pub --once /test/transform geometry_msgs/msg/Transform "{translation: {x: 0.1, y: 0.2, z: 0.3}, rotation: {x: 2.0, y: 3.0, z: 4.0, w: 1.0}}"
```

O3DE terminal:
```
(Script) - Received quaternion value x: 2.0
(Script) - Received quaternion value y: 3.0
(Script) - Received quaternion value z: 4.0
(Script) - Received quaternion value w: 1.0
(Script) - Received vector value x: 1.0
(Script) - Received vector value y: 2.0
(Script) - Received vector value z: 3.0
(Script) - Received transform translation value x: 0.10000000149012
(Script) - Received transform translation value y: 0.20000000298023
(Script) - Received transform translation value z: 0.30000001192093
(Script) - Received transform rotation value x: 2.0
(Script) - Received transform rotation value y: 3.0
(Script) - Received transform rotation value z: 4.0
(Script) - Received transform rotation value w: 1.0
```