### PR TITLE
Fixes for ROS2ScriptIntegration 

### DIFF
--- a/Gems/ROS2ScriptIntegration/Code/CMakeLists.txt
+++ b/Gems/ROS2ScriptIntegration/Code/CMakeLists.txt
@@ -129,7 +129,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                Gem::${gem_name}.Private.Object
                 Gem::ROS2.Static
     )
 

--- a/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptPublisherBus.h
+++ b/Gems/ROS2ScriptIntegration/Code/Include/ROS2ScriptIntegration/ROS2ScriptPublisherBus.h
@@ -25,7 +25,7 @@ namespace ROS2ScriptIntegration
         AZ_RTTI(PublisherRequests, "{b8356874-f7ba-4436-8d98-a342d7c720d9}");
         static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        virtual void PublishStdMsgsString(const AZStd::string& topicName, const AZStd::string& value) = 0;
+        virtual void PublishStdMsgString(const AZStd::string& topicName, const AZStd::string& value) = 0;
         virtual void PublishStdMsgEmpty(const AZStd::string& topicName) = 0;
         virtual void PublishStdMsgUInt32(const AZStd::string& topicName, const uint32_t value) = 0;
         virtual void PublishStdMsgInt32(const AZStd::string& topicName, const int32_t value) = 0;

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/PublisherSystemComponent.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/PublisherSystemComponent.cpp
@@ -86,7 +86,7 @@ namespace ROS2ScriptIntegration
     }
 
     // Publishers overrides ...
-    void PublisherSystemComponent::PublishStdMsgsString(const AZStd::string& topicName, const AZStd::string& value)
+    void PublisherSystemComponent::PublishStdMsgString(const AZStd::string& topicName, const AZStd::string& value)
     {
         std_msgs::msg::String message;
         message.data = std::string(value.c_str());

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/PublisherSystemComponent.h
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/PublisherSystemComponent.h
@@ -38,7 +38,7 @@ namespace ROS2ScriptIntegration
 
     protected:
         // ROS2ScriptIntegrationRequestBus::Handler overrides ...
-        void PublishStdMsgsString(const AZStd::string& topicName, const AZStd::string& value) override;
+        void PublishStdMsgString(const AZStd::string& topicName, const AZStd::string& value) override;
 
         void PublishStdMsgEmpty(const AZStd::string& topicName) override;
 

--- a/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptPublisherBus.cpp
+++ b/Gems/ROS2ScriptIntegration/Code/Source/Clients/ROS2ScriptPublisherBus.cpp
@@ -14,8 +14,7 @@ namespace ROS2ScriptIntegration
                 ->Attribute(AZ::Script::Attributes::Category, "ROS2")
                 ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
                 ->Attribute(AZ::Script::Attributes::Module, "ROS2")
-                ->Event(
-                    "PublishStdMsgsString", &PublisherRequestBus::Events::PublishStdMsgsString, { { { "Topic", "" }, { "Value", "" } } })
+                ->Event("PublishStdMsgString", &PublisherRequestBus::Events::PublishStdMsgString, { { { "Topic", "" }, { "Value", "" } } })
                 ->Event("PublishStdMsgEmpty", &PublisherRequestBus::Events::PublishStdMsgEmpty, { { { "Topic", "" } } })
                 ->Event("PublishStdMsgUInt32", &PublisherRequestBus::Events::PublishStdMsgUInt32, { { { "Topic", "" }, { "Value", "" } } })
                 ->Event("PublishStdMsgInt32", &PublisherRequestBus::Events::PublishStdMsgInt32, { { { "Topic", "" }, { "Value", "" } } })

--- a/Gems/ROS2ScriptIntegration/README.md
+++ b/Gems/ROS2ScriptIntegration/README.md
@@ -24,7 +24,7 @@ Let us write a simple publisher using Script Canvas.
 The "OnGraphStart" node is called on the component being activated. 
 It activates a "Heart Beat" node.
 The "Heart Beat" node is configured to issue a pulse every 100 milliseconds.
-Finally, pulse cause the publication message by node `PublishStdMsgsString`.
+Finally, pulse cause the publication message by node `PublishStdMsgString`.
 
 **Note** that the publisher is initialized on the first pulse.
 To see your messages, start the simulation and type in the terminal:
@@ -37,9 +37,9 @@ You should see new messages arriving with a frequency of 10 Hertz.
 
 The message can be published from LUA scripting language using a single call:
 ```lua
-PublisherRequestBus.Broadcast.PublishStdMsgsString("/hello", "Hello world from Lua")
+PublisherRequestBus.Broadcast.PublishStdMsgString("/hello", "Hello world from Lua")
 ```
-in which the first parameter is a topic name and the rest of the parameters form the message (only one string in `PublishStdMsgsString` method).
+in which the first parameter is a topic name and the rest of the parameters form the message (only one string in `PublishStdMsgString` method).
 
 ## Subscriber
 


### PR DESCRIPTION
There ROS2ScriptIntegration:
1. One topic with the typo was renamed to keep the convention
2. cmake was fixed

Ad 2.
I tried to use this package when building a monolithic build on Ubuntu 2404 but I got the following error:
```bash
[INFO] root: Running process 'cmake' with PID(6933): ['cmake', '--build', PosixPath('/home/jhanca/devroot/projects/FlasheyeCraneSensors/build/tools'), '--config', 'profile', '--target', 'AssetProcessorBatch', 'AssetBundlerBatch']
[INFO] root: ninja: error: 'External/ROS2ScriptIntegration-bc386a44/Code/CMakeFiles/ROS2ScriptIntegration.Private.Object.dir/profile/Source/ROS2ScriptIntegrationModuleInterface.cpp.o', needed by 'bin/profile/libROS2ScriptIntegration.Editor.so', missing and no known rule to make it
```
This PR fixes it.