### PR TITLE
Added check whether the cursor is constrained or not

### DIFF
--- a/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
+++ b/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
@@ -108,6 +108,12 @@ namespace RobotecSpectatorCamera
 
         if (channelId == AzFramework::InputDeviceMouse::Button::Right || m_configuration.m_cameraMode == CameraMode::FreeFlying)
         {
+            AzFramework::SystemCursorState currentCursorState;
+            AzFramework::InputSystemCursorRequestBus::EventResult(
+                currentCursorState, AzFramework::InputDeviceMouse::Id, &AzFramework::InputSystemCursorRequests::GetSystemCursorState);
+            const bool isConstrained = // flag to do not lose information whether the cursor is constrained or not
+                (currentCursorState == AzFramework::SystemCursorState::ConstrainedAndHidden ||
+                 currentCursorState == AzFramework::SystemCursorState::ConstrainedAndVisible);
             if (inputChannel.IsStateBegan())
             {
                 m_isRightMouseButtonPressed = true;
@@ -118,7 +124,8 @@ namespace RobotecSpectatorCamera
                 AzFramework::InputSystemCursorRequestBus::Event(
                     AzFramework::InputDeviceMouse::Id,
                     &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
-                    AzFramework::SystemCursorState::ConstrainedAndHidden);
+                    isConstrained ? AzFramework::SystemCursorState::ConstrainedAndHidden
+                                  : AzFramework::SystemCursorState::UnconstrainedAndHidden);
             }
             else if (inputChannel.IsStateEnded())
             {
@@ -135,7 +142,8 @@ namespace RobotecSpectatorCamera
                 AzFramework::InputSystemCursorRequestBus::Event(
                     AzFramework::InputDeviceMouse::Id,
                     &AzFramework::InputSystemCursorRequests::SetSystemCursorState,
-                    AzFramework::SystemCursorState::ConstrainedAndVisible);
+                    isConstrained ? AzFramework::SystemCursorState::ConstrainedAndVisible
+                                  : AzFramework::SystemCursorState::UnconstrainedAndVisible);
             }
         }
 


### PR DESCRIPTION
Changing the visibility of the cursor for the RobotecSpectatorCamera Component was added in [#50](https://github.com/RobotecAI/robotec-o3de-tools/pull/50). It works fine but it does not take into account whether the cursor was constrained or not - and this should not be changed by this component. 