### PR TITLE
[Pointcloud] Update to 2409 version

### DIFF
--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
@@ -61,7 +61,7 @@ namespace Pointcloud
         AzFramework::BoundsRequestBus::Handler::BusDisconnect();
     }
 
-    AZ::Aabb PointcloudEditorComponent::GetWorldBounds()
+    AZ::Aabb PointcloudEditorComponent::GetWorldBounds() const
     {
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
@@ -73,7 +73,7 @@ namespace Pointcloud
         return bounds;
     }
 
-    AZ::Aabb PointcloudEditorComponent::GetLocalBounds()
+    AZ::Aabb PointcloudEditorComponent::GetLocalBounds() const
     {
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetLocalTM);

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.h
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.h
@@ -42,8 +42,8 @@ namespace Pointcloud
         void Deactivate() override;
 
         // AzFramework::BoundsRequestBus overrides ...
-        AZ::Aabb GetWorldBounds() override;
-        AZ::Aabb GetLocalBounds() override;
+        AZ::Aabb GetWorldBounds() const override;
+        AZ::Aabb GetLocalBounds() const override;
 
         // AzToolsFramework::EditorComponentSelectionRequestsBus overrides ...
         AZ::Aabb GetEditorSelectionBoundsViewport(const AzFramework::ViewportInfo& viewportInfo) override;

--- a/Gems/Pointcloud/gem.json
+++ b/Gems/Pointcloud/gem.json
@@ -1,13 +1,13 @@
 {
     "gem_name": "Pointcloud",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "display_name": "Pointcloud",
-    "license": "License used i.e. Apache-2.0 or MIT",
-    "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
-    "origin": "The name of the originator or creator",
-    "origin_url": "The website for this Gem",
+    "license": "Apache-2.0",
+    "license_url": "https://opensource.org/licenses/Apache-2.0",
+    "origin": "Robotec.AI",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
-    "summary": "A short description of this Gem",
+    "summary": "Tool Gem to visualize point clouds",
     "canonical_tags": [
         "Gem"
     ],
@@ -24,8 +24,8 @@
         "Atom_RPI",
         "Atom"
     ],
-    "repo_uri": "",
-    "compatible_engines": [],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "compatible_engines": ["o3de>=2.3.0"],
     "engine_api_dependencies": [],
     "restricted": "Pointcloud"
 }


### PR DESCRIPTION
This PR updates the Pointcloud to work with 2409. The API of AzFramework::BoundsBus has changed and the main driver is to fix compilation.

Additionally: 
* update compatible_engines
* bump Gem version
* minor adjustments in Gem description