### PR TITLE
Wc/snap to terrain - CsvSpawner: Make "snap to terrain" based on collision layer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/**
+.idea/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/**
 .idea/**
+

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerComponent.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerComponent.cpp
@@ -47,14 +47,19 @@ namespace CsvSpawner
         AZ::TickBus ::Handler::BusDisconnect();
     }
 
+    int CsvSpawnerComponent::GetTickOrder()
+    {
+        return AZ::TICK_LAST;
+    }
+
     void CsvSpawnerComponent::Activate()
     {
-        AZ::TickBus ::Handler::BusConnect();
+        AZ::TickBus::Handler::BusConnect();
     }
 
     void CsvSpawnerComponent::Deactivate()
     {
-        AZ::TickBus ::Handler::BusDisconnect();
+        AZ::TickBus::Handler::BusDisconnect();
     }
 
 } // namespace CsvSpawner

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerComponent.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerComponent.h
@@ -48,6 +48,7 @@ namespace CsvSpawner
     private:
         // AZ::TickBus::Handler overrides
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        int GetTickOrder() override;
 
         AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> m_spawnableAssetConfigurations; //!< List of assets to spawn
         AZStd::vector<CsvSpawnableEntityInfo> m_spawnableEntityInfo; //!< List of entities to spawn

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.cpp
@@ -86,12 +86,6 @@ namespace CsvSpawner
         }
 
         AZ::TickBus::Handler::BusConnect();
-        AZ::TickBus::QueueFunction(
-            [this]()
-            {
-                std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                SpawnEntities();
-            });
     }
 
     void CsvSpawnerEditorComponent::Deactivate()
@@ -129,18 +123,12 @@ namespace CsvSpawner
 
     void CsvSpawnerEditorComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
-        if (m_entitiesSpawnedOnce)
-        {
-            return;
-        }
-
         ++m_frameCounter;
 
         if (m_frameCounter == 2)
         {
             SpawnEntities();
             AZ::TickBus::Handler::BusDisconnect();
-            m_entitiesSpawnedOnce = true;
         }
     }
 

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.cpp
@@ -129,6 +129,7 @@ namespace CsvSpawner
         {
             SpawnEntities();
             AZ::TickBus::Handler::BusDisconnect();
+            m_frameCounter = 0;
         }
     }
 

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.h
@@ -10,7 +10,9 @@
 
 #pragma once
 
+#include "API/ToolsApplicationAPI.h"
 #include "CsvSpawnerUtils.h"
+
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Entity/EntityContextBus.h>
@@ -28,6 +30,7 @@ namespace CsvSpawner
     class CsvSpawnerEditorComponent
         : public AzToolsFramework::Components::EditorComponentBase
         , protected AzFramework::ViewportDebugDisplayEventBus::Handler
+        , protected AZ::TickBus::Handler
     {
     public:
         AZ_EDITOR_COMPONENT(CsvSpawnerEditorComponent, CsvSpawnerEditorComponentTypeId);
@@ -40,6 +43,8 @@ namespace CsvSpawner
         void Activate() override;
         void Deactivate() override;
         void BuildGameEntity(AZ::Entity* gameEntity) override;
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        int GetTickOrder() override;
 
     private:
         // EntityDebugDisplayEventBus::Handler overrides
@@ -50,6 +55,8 @@ namespace CsvSpawner
         void OnOnShowLabelsChanged();
 
         void SpawnEntities();
+        bool m_entitiesSpawnedOnce = false;
+        int m_frameCounter;
 
         AZStd::vector<CsvSpawnerUtils::CsvSpawnableAssetConfiguration>
             m_spawnableAssetConfigurations; //!< List of spawnable "types" (e.g. pineCsv, oakTre, mapleCsv, etc.)

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerEditorComponent.h
@@ -55,7 +55,6 @@ namespace CsvSpawner
         void OnOnShowLabelsChanged();
 
         void SpawnEntities();
-        bool m_entitiesSpawnedOnce = false;
         int m_frameCounter;
 
         AZStd::vector<CsvSpawnerUtils::CsvSpawnableAssetConfiguration>

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -185,7 +185,7 @@ namespace CsvSpawner::CsvSpawnerUtils
         const AzPhysics::SceneHandle sceneHandle,
         const AZ::Vector3& gravityDirection,
         float maxDistance,
-        AzPhysics::CollisionLayer collisionLayer)
+        const AzPhysics::CollisionLayer& collisionLayer)
     {
         AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
 

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -24,295 +24,298 @@
 #include <cstdlib>
 #include <random>
 
-namespace CsvSpawner::CsvSpawnerUtils {
+namespace CsvSpawner::CsvSpawnerUtils
+{
 
-void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext *context) {
-  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
-    serializeContext->Class<CsvSpawnableEntityInfo>()
-        ->Version(1)
-        ->Field("Id", &CsvSpawnableEntityInfo::m_id)
-        ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
-        ->Field("Name", &CsvSpawnableEntityInfo::m_name)
-        ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
-  }
-}
-void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext *context) {
-  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
-    serializeContext->Class<CsvSpawnableAssetConfiguration>()
-        ->Version(1)
-        ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
-        ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
-        ->Field("PositionStdDev",
-                &CsvSpawnableAssetConfiguration::m_positionStdDev)
-        ->Field("RotationStdDev",
-                &CsvSpawnableAssetConfiguration::m_rotationStdDev)
-        ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
-        ->Field("PlaceOnTerrain",
-                &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
-        ->Field("CollisionLayer",
-                &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer);
+    void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CsvSpawnableEntityInfo>()
+                ->Version(1)
+                ->Field("Id", &CsvSpawnableEntityInfo::m_id)
+                ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
+                ->Field("Name", &CsvSpawnableEntityInfo::m_name)
+                ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
+        }
+    }
+    void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CsvSpawnableAssetConfiguration>()
+                ->Version(1)
+                ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
+                ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
+                ->Field("PositionStdDev", &CsvSpawnableAssetConfiguration::m_positionStdDev)
+                ->Field("RotationStdDev", &CsvSpawnableAssetConfiguration::m_rotationStdDev)
+                ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
+                ->Field("PlaceOnTerrain", &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
+                ->Field("CollisionLayer", &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer);
 
-    if (auto *editContext = serializeContext->GetEditContext()) {
-      editContext
-          ->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration",
-                                                  "SpawnableAssetConfiguration")
-          ->ClassElement(AZ::Edit::ClassElements::EditorData,
-                         "SpawnableAssetConfiguration")
-          ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu,
-                      AZ_CRC_CE("Game"))
-          ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
-          ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-          ->DataElement(AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_name, "Name",
-                        "Name of the spawnable field")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_spawnables,
-                        "Spawnables", "Vector of spawnables")
-          ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern,
-                      "*.spawnable")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration", "SpawnableAssetConfiguration")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "SpawnableAssetConfiguration")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_name, "Name", "Name of the spawnable field")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_spawnables, "Spawnables", "Vector of spawnables")
+                    ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern, "*.spawnable")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_positionStdDev,
                         "Position Std. Dev.",
                         "Position standard deviation, in meters")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_rotationStdDev,
                         "Rotation Std. Dev. ",
                         "Rotation standard deviation, in degrees")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on Terrain",
                         "Perform scene query raytrace to place on terrain")
-          ->Attribute(AZ::Edit::Attributes::ChangeNotify,
-                      &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_scaleStdDev,
                         "Scale Std. Dev.",
                         "Scale standard deviation, in meters")
-          ->DataElement(
-              AZ::Edit::UIHandlers::Default,
-              &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer,
-              "Collision Layer",
-              "To which collision layer this target will be attached")
-          ->Attribute(AZ::Edit::Attributes::ReadOnly,
-                      &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
-    }
-  }
-}
-
-bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const {
-  return !m_placeOnTerrain;
-}
-
-AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged() {
-  return AZ::Edit::PropertyRefreshLevels::EntireTree;
-}
-
-AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-GetSpawnableAssetFromVector(AZStd::vector<CsvSpawnableAssetConfiguration>
-                                spawnableAssetConfigurations) {
-  AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-      spawnableAssetConfiguration;
-  for (auto &spawnableAssetConfigurationElement :
-       spawnableAssetConfigurations) {
-    spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] =
-        spawnableAssetConfigurationElement;
-  }
-  return spawnableAssetConfiguration;
-}
-
-template <typename T>
-T GetRandomElement(const AZStd::vector<T> &vec, std::mt19937 &gen) {
-  std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
-  return vec.at(distribution(gen));
-}
-
-AZ::Transform GetRandomTransform(const AZ::Vector3 &stdDevTranslation,
-                                 const AZ::Vector3 &stdDevRotation,
-                                 float stdDevScale, std::mt19937 &gen) {
-  AZ::Transform transform = AZ::Transform::CreateIdentity();
-  AZStd::vector<std::normal_distribution<float>> distributions;
-  distributions.emplace_back(0.0f, stdDevTranslation.GetX());
-  distributions.emplace_back(0.0f, stdDevTranslation.GetY());
-  distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
-  distributions.emplace_back(0.0f, stdDevRotation.GetX());
-  distributions.emplace_back(0.0f, stdDevRotation.GetY());
-  distributions.emplace_back(0.0f, stdDevRotation.GetZ());
-  distributions.emplace_back(1.0f, stdDevScale);
-
-  transform.SetTranslation(AZ::Vector3(
-      distributions[0](gen), distributions[1](gen), distributions[2](gen)));
-  const AZ::Quaternion rotation =
-      AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(
-          distributions[3](gen), distributions[4](gen), distributions[5](gen)));
-  transform.SetRotation(rotation);
-  transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
-  return transform;
-}
-
-AZStd::optional<AZ::Vector3>
-RaytraceTerrain(const AZ::Vector3 &location,
-                const AzPhysics::SceneHandle sceneHandle,
-                const AZ::Vector3 &gravityDirection, float maxDistance) {
-  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
-    return hitPosition;
-  }
-
-  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-  AZ_Assert(physicsSystem, "Unable to get physics system interface");
-  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-  if (!sceneInterface || !physicsSystem) {
-    return hitPosition;
-  }
-
-  AzPhysics::RayCastRequest request;
-  request.m_start = location;
-  request.m_direction = gravityDirection;
-  request.m_distance = maxDistance;
-
-  AzPhysics::SceneQueryHits result =
-      sceneInterface->QueryScene(sceneHandle, &request);
-
-  if (!result.m_hits.empty()) {
-    hitPosition = result.m_hits.front().m_position;
-  }
-
-  return hitPosition;
-}
-
-AZStd::optional<AZ::Vector3>
-RaytraceTerrain(const AZ::Vector3 &location,
-                const AzPhysics::SceneHandle sceneHandle,
-                const AZ::Vector3 &gravityDirection, float maxDistance,
-                AzPhysics::CollisionLayer collisionLayer) {
-  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-  AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle,
-            "Unable to get  scene handle");
-  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
-    return hitPosition;
-  }
-
-  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-  AZ_Assert(physicsSystem, "Unable to get physics system interface");
-  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-  if (!sceneInterface || !physicsSystem) {
-    return hitPosition;
-  }
-
-  AzPhysics::RayCastRequest request;
-  request.m_start = location;
-  request.m_direction = gravityDirection;
-  request.m_distance = maxDistance;
-  request.m_collisionGroup.SetLayer(collisionLayer, true);
-
-  AzPhysics::SceneQueryHits result =
-      sceneInterface->QueryScene(sceneHandle, &request);
-
-  if (!result.m_hits.empty()) {
-    hitPosition = result.m_hits.front().m_position;
-  }
-
-  return hitPosition;
-}
-
-AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
-    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-        &spawnableAssetConfiguration,
-    AZ::u64 defaultSeed, const AZStd::string &physicsSceneName,
-    AZ::EntityId parentId) {
-  auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-  const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
-
-  AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
-  auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-  AZ_Assert(spawner, "Unable to get spawnable entities definition");
-
-  // get parent transform
-  AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
-  if (parentId.IsValid()) {
-    AZ::TransformBus::EventResult(parentTransform, parentId,
-                                  &AZ::TransformBus::Events::GetWorldTM);
-  }
-
-  for (auto &spawnables : spawnableAssetConfiguration) {
-    for (auto spawnable : spawnables.second.m_spawnables) {
-      spawnable.QueueLoad();
-    }
-  }
-
-  for (const auto &entityConfig : entitiesToSpawn) {
-    if (!spawnableAssetConfiguration.contains(entityConfig.m_name)) {
-      AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found",
-               entityConfig.m_name.c_str());
-      continue;
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer,
+                        "Collision Layer",
+                        "To which collision layer this target will be attached")
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
+            }
+        }
     }
 
-    const auto &spawnConfig =
-        spawnableAssetConfiguration.at(entityConfig.m_name);
-
-    // if seed is not set for this row, use the default seed
-    std::mt19937 gen = entityConfig.m_seed > 0
-                           ? std::mt19937(entityConfig.m_seed)
-                           : std::mt19937(defaultSeed++);
-
-    const auto &spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
-
-    AZ::Transform transform =
-        parentTransform * entityConfig.m_transform *
-        GetRandomTransform(spawnConfig.m_positionStdDev,
-                           spawnConfig.m_rotationStdDev,
-                           spawnConfig.m_scaleStdDev, gen);
-
-    if (spawnConfig.m_placeOnTerrain) {
-      const AZStd::optional<AZ::Vector3> hitPosition = RaytraceTerrain(
-          transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(),
-          1000.0f, spawnConfig.m_selectedCollisionLayer);
-      if (hitPosition.has_value()) {
-        transform.SetTranslation(hitPosition.value());
-      } else {
-        continue; // Skip this entity if we can't find a valid position and
-                  // place on terrain is enabled.
-      }
+    bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const
+    {
+        return !m_placeOnTerrain;
     }
-    AZ_Assert(spawner, "Unable to get spawnable entities definition");
-    AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-    AzFramework::EntitySpawnTicket ticket(spawnable);
-    // Set the pre-spawn callback to set the name of the root entity to the name
-    // of the spawnable
-    optionalArgs.m_preInsertionCallback = [transform](auto id, auto view) {
-      if (view.empty()) {
-        return;
-      }
-      AZ::Entity *root = *view.begin();
-      AZ_Assert(root, "Invalid root entity");
 
-      auto *transformInterface =
-          root->FindComponent<AzFramework::TransformComponent>();
-      transformInterface->SetWorldTM(transform);
-    };
-    optionalArgs.m_completionCallback =
-        [parentId]([[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId,
-                   AzFramework::SpawnableConstEntityContainerView view) {
-          if (view.empty()) {
-            return;
-          }
-          const AZ::Entity *root = *view.begin();
-          AZ::TransformBus::Event(
-              root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
-        };
-    optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
-    spawner->SpawnAllEntities(ticket, optionalArgs);
-    tickets[entityConfig.m_id] = AZStd::move(ticket);
-  }
-  return tickets;
-}
+    AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged()
+    {
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
+        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations)
+    {
+        AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> spawnableAssetConfiguration;
+        for (auto& spawnableAssetConfigurationElement : spawnableAssetConfigurations)
+        {
+            spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] = spawnableAssetConfigurationElement;
+        }
+        return spawnableAssetConfiguration;
+    }
+
+    template<typename T>
+    T GetRandomElement(const AZStd::vector<T>& vec, std::mt19937& gen)
+    {
+        std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
+        return vec.at(distribution(gen));
+    }
+
+    AZ::Transform GetRandomTransform(
+        const AZ::Vector3& stdDevTranslation, const AZ::Vector3& stdDevRotation, float stdDevScale, std::mt19937& gen)
+    {
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZStd::vector<std::normal_distribution<float>> distributions;
+        distributions.emplace_back(0.0f, stdDevTranslation.GetX());
+        distributions.emplace_back(0.0f, stdDevTranslation.GetY());
+        distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
+        distributions.emplace_back(0.0f, stdDevRotation.GetX());
+        distributions.emplace_back(0.0f, stdDevRotation.GetY());
+        distributions.emplace_back(0.0f, stdDevRotation.GetZ());
+        distributions.emplace_back(1.0f, stdDevScale);
+
+        transform.SetTranslation(AZ::Vector3(distributions[0](gen), distributions[1](gen), distributions[2](gen)));
+        const AZ::Quaternion rotation =
+            AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(distributions[3](gen), distributions[4](gen), distributions[5](gen)));
+        transform.SetRotation(rotation);
+        transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
+        return transform;
+    }
+
+    AZStd::optional<AZ::Vector3> RaytraceTerrain(
+        const AZ::Vector3& location, const AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& gravityDirection, float maxDistance)
+    {
+        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+        if (sceneHandle == AzPhysics::InvalidSceneHandle)
+        {
+            return hitPosition;
+        }
+
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AZ_Assert(physicsSystem, "Unable to get physics system interface");
+        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+        if (!sceneInterface || !physicsSystem)
+        {
+            return hitPosition;
+        }
+
+        AzPhysics::RayCastRequest request;
+        request.m_start = location;
+        request.m_direction = gravityDirection;
+        request.m_distance = maxDistance;
+
+        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
+
+        if (!result.m_hits.empty())
+        {
+            hitPosition = result.m_hits.front().m_position;
+        }
+
+        return hitPosition;
+    }
+
+    AZStd::optional<AZ::Vector3> RaytraceTerrain(
+        const AZ::Vector3& location,
+        const AzPhysics::SceneHandle sceneHandle,
+        const AZ::Vector3& gravityDirection,
+        float maxDistance,
+        AzPhysics::CollisionLayer collisionLayer)
+    {
+        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
+        if (sceneHandle == AzPhysics::InvalidSceneHandle)
+        {
+            return hitPosition;
+        }
+
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AZ_Assert(physicsSystem, "Unable to get physics system interface");
+        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+        if (!sceneInterface || !physicsSystem)
+        {
+            return hitPosition;
+        }
+
+        AzPhysics::RayCastRequest request;
+        request.m_start = location;
+        request.m_direction = gravityDirection;
+        request.m_distance = maxDistance;
+        request.m_collisionGroup.SetLayer(collisionLayer, true);
+
+        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
+
+        if (!result.m_hits.empty())
+        {
+            hitPosition = result.m_hits.front().m_position;
+        }
+
+        return hitPosition;
+    }
+
+    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
+        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
+        AZ::u64 defaultSeed,
+        const AZStd::string& physicsSceneName,
+        AZ::EntityId parentId)
+    {
+        auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+        const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
+
+        AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
+        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+        AZ_Assert(spawner, "Unable to get spawnable entities definition");
+
+        // get parent transform
+        AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
+        if (parentId.IsValid())
+        {
+            AZ::TransformBus::EventResult(parentTransform, parentId, &AZ::TransformBus::Events::GetWorldTM);
+        }
+
+        for (auto& spawnables : spawnableAssetConfiguration)
+        {
+            for (auto spawnable : spawnables.second.m_spawnables)
+            {
+                spawnable.QueueLoad();
+            }
+        }
+
+        for (const auto& entityConfig : entitiesToSpawn)
+        {
+            if (!spawnableAssetConfiguration.contains(entityConfig.m_name))
+            {
+                AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found", entityConfig.m_name.c_str());
+                continue;
+            }
+
+            const auto& spawnConfig = spawnableAssetConfiguration.at(entityConfig.m_name);
+
+            // if seed is not set for this row, use the default seed
+            std::mt19937 gen = entityConfig.m_seed > 0 ? std::mt19937(entityConfig.m_seed) : std::mt19937(defaultSeed++);
+
+            const auto& spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
+
+            AZ::Transform transform = parentTransform * entityConfig.m_transform *
+                GetRandomTransform(spawnConfig.m_positionStdDev, spawnConfig.m_rotationStdDev, spawnConfig.m_scaleStdDev, gen);
+
+            if (spawnConfig.m_placeOnTerrain)
+            {
+                const AZStd::optional<AZ::Vector3> hitPosition = RaytraceTerrain(
+                    transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(), 1000.0f, spawnConfig.m_selectedCollisionLayer);
+                if (hitPosition.has_value())
+                {
+                    transform.SetTranslation(hitPosition.value());
+                }
+                else
+                {
+                    continue; // Skip this entity if we can't find a valid position and
+                              // place on terrain is enabled.
+                }
+            }
+            AZ_Assert(spawner, "Unable to get spawnable entities definition");
+            AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+            AzFramework::EntitySpawnTicket ticket(spawnable);
+            // Set the pre-spawn callback to set the name of the root entity to the name
+            // of the spawnable
+            optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
+            {
+                if (view.empty())
+                {
+                    return;
+                }
+                AZ::Entity* root = *view.begin();
+                AZ_Assert(root, "Invalid root entity");
+
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetWorldTM(transform);
+            };
+            optionalArgs.m_completionCallback =
+                [parentId](
+                    [[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId, AzFramework::SpawnableConstEntityContainerView view)
+            {
+                if (view.empty())
+                {
+                    return;
+                }
+                const AZ::Entity* root = *view.begin();
+                AZ::TransformBus::Event(root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
+            };
+            optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
+            spawner->SpawnAllEntities(ticket, optionalArgs);
+            tickets[entityConfig.m_id] = AZStd::move(ticket);
+        }
+        return tickets;
+    }
 
 } // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -27,268 +27,269 @@
 #include <cstdlib>
 #include <random>
 
-namespace CsvSpawner::CsvSpawnerUtils {
+namespace CsvSpawner::CsvSpawnerUtils
+{
 
-void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext *context) {
-  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
-    serializeContext->Class<CsvSpawnableEntityInfo>()
-        ->Version(1)
-        ->Field("Id", &CsvSpawnableEntityInfo::m_id)
-        ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
-        ->Field("Name", &CsvSpawnableEntityInfo::m_name)
-        ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
-  }
-}
-void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext *context) {
-  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
-    serializeContext->Class<CsvSpawnableAssetConfiguration>()
-        ->Version(1)
-        ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
-        ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
-        ->Field("PositionStdDev",
-                &CsvSpawnableAssetConfiguration::m_positionStdDev)
-        ->Field("RotationStdDev",
-                &CsvSpawnableAssetConfiguration::m_rotationStdDev)
-        ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
-        ->Field("PlaceOnTerrain",
-                &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
-        ->Field("CollisionGroup",
-                &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup);
+    void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CsvSpawnableEntityInfo>()
+                ->Version(1)
+                ->Field("Id", &CsvSpawnableEntityInfo::m_id)
+                ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
+                ->Field("Name", &CsvSpawnableEntityInfo::m_name)
+                ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
+        }
+    }
+    void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<CsvSpawnableAssetConfiguration>()
+                ->Version(1)
+                ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
+                ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
+                ->Field("PositionStdDev", &CsvSpawnableAssetConfiguration::m_positionStdDev)
+                ->Field("RotationStdDev", &CsvSpawnableAssetConfiguration::m_rotationStdDev)
+                ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
+                ->Field("PlaceOnTerrain", &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
+                ->Field("CollisionGroup", &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup);
 
-    if (auto *editContext = serializeContext->GetEditContext()) {
-      editContext
-          ->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration",
-                                                  "SpawnableAssetConfiguration")
-          ->ClassElement(AZ::Edit::ClassElements::EditorData,
-                         "SpawnableAssetConfiguration")
-          ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu,
-                      AZ_CRC_CE("Game"))
-          ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
-          ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-          ->DataElement(AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_name, "Name",
-                        "Name of the spawnable field")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_spawnables,
-                        "Spawnables", "Vector of spawnables")
-          ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern,
-                      "*.spawnable")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration", "SpawnableAssetConfiguration")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "SpawnableAssetConfiguration")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_name, "Name", "Name of the spawnable field")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_spawnables, "Spawnables", "Vector of spawnables")
+                    ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern, "*.spawnable")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_positionStdDev,
                         "Position Std. Dev.",
                         "Position standard deviation, in meters")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_rotationStdDev,
                         "Rotation Std. Dev. ",
                         "Rotation standard deviation, in degrees")
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on Terrain",
                         "Perform scene query raytrace to place on terrain")
-          ->Attribute(AZ::Edit::Attributes::ChangeNotify,
-                      &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
-          ->DataElement(AZ::Edit::UIHandlers::Default,
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_scaleStdDev,
                         "Scale Std. Dev.",
                         "Scale standard deviation, in meters")
-          ->DataElement(
-              AZ::Edit::UIHandlers::Default,
-              &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup,
-              "Collision Group",
-              "To which collision group this target will be attached")
-          ->Attribute(AZ::Edit::Attributes::ReadOnly,
-                      &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
-    }
-  }
-}
-
-bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const {
-  return !m_placeOnTerrain;
-}
-
-AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged() {
-  return AZ::Edit::PropertyRefreshLevels::EntireTree;
-}
-
-AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-GetSpawnableAssetFromVector(AZStd::vector<CsvSpawnableAssetConfiguration>
-                                spawnableAssetConfigurations) {
-  AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-      spawnableAssetConfiguration;
-  for (auto &spawnableAssetConfigurationElement :
-       spawnableAssetConfigurations) {
-    spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] =
-        spawnableAssetConfigurationElement;
-  }
-  return spawnableAssetConfiguration;
-}
-
-template <typename T>
-T GetRandomElement(const AZStd::vector<T> &vec, std::mt19937 &gen) {
-  std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
-  return vec.at(distribution(gen));
-}
-
-AZ::Transform GetRandomTransform(const AZ::Vector3 &stdDevTranslation,
-                                 const AZ::Vector3 &stdDevRotation,
-                                 float stdDevScale, std::mt19937 &gen) {
-  AZ::Transform transform = AZ::Transform::CreateIdentity();
-  AZStd::vector<std::normal_distribution<float>> distributions;
-  distributions.emplace_back(0.0f, stdDevTranslation.GetX());
-  distributions.emplace_back(0.0f, stdDevTranslation.GetY());
-  distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
-  distributions.emplace_back(0.0f, stdDevRotation.GetX());
-  distributions.emplace_back(0.0f, stdDevRotation.GetY());
-  distributions.emplace_back(0.0f, stdDevRotation.GetZ());
-  distributions.emplace_back(1.0f, stdDevScale);
-
-  transform.SetTranslation(AZ::Vector3(
-      distributions[0](gen), distributions[1](gen), distributions[2](gen)));
-  const AZ::Quaternion rotation =
-      AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(
-          distributions[3](gen), distributions[4](gen), distributions[5](gen)));
-  transform.SetRotation(rotation);
-  transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
-  return transform;
-}
-
-AZStd::optional<AZ::Vector3>
-RaytraceTerrain(const AZ::Vector3 &location,
-                const AzPhysics::SceneHandle sceneHandle,
-                const AZ::Vector3 &gravityDirection, float maxDistance,
-                const AzPhysics::CollisionGroup &collisionGroup) {
-  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-  AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle,
-            "Unable to get  scene handle");
-  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
-    return hitPosition;
-  }
-
-  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-  AZ_Assert(physicsSystem, "Unable to get physics system interface");
-  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-  if (!sceneInterface || !physicsSystem) {
-    return hitPosition;
-  }
-
-  AzPhysics::RayCastRequest request;
-  request.m_start = location;
-  request.m_direction = gravityDirection;
-  request.m_distance = maxDistance;
-  request.m_collisionGroup = collisionGroup;
-
-  AzPhysics::SceneQueryHits result =
-      sceneInterface->QueryScene(sceneHandle, &request);
-
-  if (!result.m_hits.empty()) {
-    hitPosition = result.m_hits.front().m_position;
-  }
-
-  return hitPosition;
-}
-
-AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
-    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-        &spawnableAssetConfiguration,
-    AZ::u64 defaultSeed, const AZStd::string &physicsSceneName,
-    AZ::EntityId parentId) {
-  auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-  const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
-
-  AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
-  auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-  AZ_Assert(spawner, "Unable to get spawnable entities definition");
-
-  // get parent transform
-  AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
-  if (parentId.IsValid()) {
-    AZ::TransformBus::EventResult(parentTransform, parentId,
-                                  &AZ::TransformBus::Events::GetWorldTM);
-  }
-
-  for (auto &spawnables : spawnableAssetConfiguration) {
-    for (auto spawnable : spawnables.second.m_spawnables) {
-      spawnable.QueueLoad();
-    }
-  }
-
-  for (const auto &entityConfig : entitiesToSpawn) {
-    if (!spawnableAssetConfiguration.contains(entityConfig.m_name)) {
-      AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found",
-               entityConfig.m_name.c_str());
-      continue;
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup,
+                        "Collision Group",
+                        "To which collision group this target will be attached")
+                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
+            }
+        }
     }
 
-    const auto &spawnConfig =
-        spawnableAssetConfiguration.at(entityConfig.m_name);
-
-    // if seed is not set for this row, use the default seed
-    std::mt19937 gen = entityConfig.m_seed > 0
-                           ? std::mt19937(entityConfig.m_seed)
-                           : std::mt19937(defaultSeed++);
-
-    const auto &spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
-
-    AZ::Transform transform =
-        parentTransform * entityConfig.m_transform *
-        GetRandomTransform(spawnConfig.m_positionStdDev,
-                           spawnConfig.m_rotationStdDev,
-                           spawnConfig.m_scaleStdDev, gen);
-
-    if (spawnConfig.m_placeOnTerrain) {
-      // Get collision group chosen from editor
-      AzPhysics::CollisionGroup collisionGroup;
-      Physics::CollisionRequestBus::BroadcastResult(
-          collisionGroup, &Physics::CollisionRequests::GetCollisionGroupById,
-          spawnConfig.m_selectedCollisionGroup);
-
-      const AZStd::optional<AZ::Vector3> hitPosition =
-          RaytraceTerrain(transform.GetTranslation(), sceneHandle,
-                          -AZ::Vector3::CreateAxisZ(), 1000.0f, collisionGroup);
-
-      if (hitPosition.has_value()) {
-        transform.SetTranslation(hitPosition.value());
-      } else {
-        continue; // Skip this entity if we can't find a valid position and
-                  // place on terrain is enabled.
-      }
+    bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const
+    {
+        return !m_placeOnTerrain;
     }
-    AZ_Assert(spawner, "Unable to get spawnable entities definition");
-    AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-    AzFramework::EntitySpawnTicket ticket(spawnable);
-    // Set the pre-spawn callback to set the name of the root entity to the name
-    // of the spawnable
-    optionalArgs.m_preInsertionCallback = [transform](auto id, auto view) {
-      if (view.empty()) {
-        return;
-      }
-      AZ::Entity *root = *view.begin();
-      AZ_Assert(root, "Invalid root entity");
 
-      auto *transformInterface =
-          root->FindComponent<AzFramework::TransformComponent>();
-      transformInterface->SetWorldTM(transform);
-    };
-    optionalArgs.m_completionCallback =
-        [parentId]([[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId,
-                   AzFramework::SpawnableConstEntityContainerView view) {
-          if (view.empty()) {
-            return;
-          }
-          const AZ::Entity *root = *view.begin();
-          AZ::TransformBus::Event(
-              root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
-        };
-    optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
-    spawner->SpawnAllEntities(ticket, optionalArgs);
-    tickets[entityConfig.m_id] = AZStd::move(ticket);
-  }
-  return tickets;
-}
+    AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged()
+    {
+        return AZ::Edit::PropertyRefreshLevels::EntireTree;
+    }
+
+    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
+        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations)
+    {
+        AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> spawnableAssetConfiguration;
+        for (auto& spawnableAssetConfigurationElement : spawnableAssetConfigurations)
+        {
+            spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] = spawnableAssetConfigurationElement;
+        }
+        return spawnableAssetConfiguration;
+    }
+
+    template<typename T>
+    T GetRandomElement(const AZStd::vector<T>& vec, std::mt19937& gen)
+    {
+        std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
+        return vec.at(distribution(gen));
+    }
+
+    AZ::Transform GetRandomTransform(
+        const AZ::Vector3& stdDevTranslation, const AZ::Vector3& stdDevRotation, float stdDevScale, std::mt19937& gen)
+    {
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZStd::vector<std::normal_distribution<float>> distributions;
+        distributions.emplace_back(0.0f, stdDevTranslation.GetX());
+        distributions.emplace_back(0.0f, stdDevTranslation.GetY());
+        distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
+        distributions.emplace_back(0.0f, stdDevRotation.GetX());
+        distributions.emplace_back(0.0f, stdDevRotation.GetY());
+        distributions.emplace_back(0.0f, stdDevRotation.GetZ());
+        distributions.emplace_back(1.0f, stdDevScale);
+
+        transform.SetTranslation(AZ::Vector3(distributions[0](gen), distributions[1](gen), distributions[2](gen)));
+        const AZ::Quaternion rotation =
+            AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(distributions[3](gen), distributions[4](gen), distributions[5](gen)));
+        transform.SetRotation(rotation);
+        transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
+        return transform;
+    }
+
+    AZStd::optional<AZ::Vector3> RaytraceTerrain(
+        const AZ::Vector3& location,
+        const AzPhysics::SceneHandle sceneHandle,
+        const AZ::Vector3& gravityDirection,
+        float maxDistance,
+        const AzPhysics::CollisionGroup& collisionGroup)
+    {
+        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
+        if (sceneHandle == AzPhysics::InvalidSceneHandle)
+        {
+            return hitPosition;
+        }
+
+        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AZ_Assert(physicsSystem, "Unable to get physics system interface");
+        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+        if (!sceneInterface || !physicsSystem)
+        {
+            return hitPosition;
+        }
+
+        AzPhysics::RayCastRequest request;
+        request.m_start = location;
+        request.m_direction = gravityDirection;
+        request.m_distance = maxDistance;
+        request.m_collisionGroup = collisionGroup;
+
+        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
+
+        if (!result.m_hits.empty())
+        {
+            hitPosition = result.m_hits.front().m_position;
+        }
+
+        return hitPosition;
+    }
+
+    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
+        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
+        AZ::u64 defaultSeed,
+        const AZStd::string& physicsSceneName,
+        AZ::EntityId parentId)
+    {
+        auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+        const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
+
+        AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
+        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+        AZ_Assert(spawner, "Unable to get spawnable entities definition");
+
+        // get parent transform
+        AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
+        if (parentId.IsValid())
+        {
+            AZ::TransformBus::EventResult(parentTransform, parentId, &AZ::TransformBus::Events::GetWorldTM);
+        }
+
+        for (auto& spawnables : spawnableAssetConfiguration)
+        {
+            for (auto spawnable : spawnables.second.m_spawnables)
+            {
+                spawnable.QueueLoad();
+            }
+        }
+
+        for (const auto& entityConfig : entitiesToSpawn)
+        {
+            if (!spawnableAssetConfiguration.contains(entityConfig.m_name))
+            {
+                AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found", entityConfig.m_name.c_str());
+                continue;
+            }
+
+            const auto& spawnConfig = spawnableAssetConfiguration.at(entityConfig.m_name);
+
+            // if seed is not set for this row, use the default seed
+            std::mt19937 gen = entityConfig.m_seed > 0 ? std::mt19937(entityConfig.m_seed) : std::mt19937(defaultSeed++);
+
+            const auto& spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
+
+            AZ::Transform transform = parentTransform * entityConfig.m_transform *
+                GetRandomTransform(spawnConfig.m_positionStdDev, spawnConfig.m_rotationStdDev, spawnConfig.m_scaleStdDev, gen);
+
+            if (spawnConfig.m_placeOnTerrain)
+            {
+                // Get collision group chosen from editor
+                AzPhysics::CollisionGroup collisionGroup;
+                Physics::CollisionRequestBus::BroadcastResult(
+                    collisionGroup, &Physics::CollisionRequests::GetCollisionGroupById, spawnConfig.m_selectedCollisionGroup);
+
+                const AZStd::optional<AZ::Vector3> hitPosition =
+                    RaytraceTerrain(transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(), 1000.0f, collisionGroup);
+
+                if (hitPosition.has_value())
+                {
+                    transform.SetTranslation(hitPosition.value());
+                }
+                else
+                {
+                    continue; // Skip this entity if we can't find a valid position and
+                              // place on terrain is enabled.
+                }
+            }
+            AZ_Assert(spawner, "Unable to get spawnable entities definition");
+            AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+            AzFramework::EntitySpawnTicket ticket(spawnable);
+            // Set the pre-spawn callback to set the name of the root entity to the name
+            // of the spawnable
+            optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
+            {
+                if (view.empty())
+                {
+                    return;
+                }
+                AZ::Entity* root = *view.begin();
+                AZ_Assert(root, "Invalid root entity");
+
+                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
+                transformInterface->SetWorldTM(transform);
+            };
+            optionalArgs.m_completionCallback =
+                [parentId](
+                    [[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId, AzFramework::SpawnableConstEntityContainerView view)
+            {
+                if (view.empty())
+                {
+                    return;
+                }
+                const AZ::Entity* root = *view.begin();
+                AZ::TransformBus::Event(root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
+            };
+            optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
+            spawner->SpawnAllEntities(ticket, optionalArgs);
+            tickets[entityConfig.m_id] = AZStd::move(ticket);
+        }
+        return tickets;
+    }
 
 } // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -183,6 +183,7 @@ namespace CsvSpawner::CsvSpawnerUtils
     {
         AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
 
+        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
         if (sceneHandle == AzPhysics::InvalidSceneHandle)
         {
             return hitPosition;

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -27,269 +27,268 @@
 #include <cstdlib>
 #include <random>
 
-namespace CsvSpawner::CsvSpawnerUtils
-{
+namespace CsvSpawner::CsvSpawnerUtils {
 
-    void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext* context)
-    {
-        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-            serializeContext->Class<CsvSpawnableEntityInfo>()
-                ->Version(1)
-                ->Field("Id", &CsvSpawnableEntityInfo::m_id)
-                ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
-                ->Field("Name", &CsvSpawnableEntityInfo::m_name)
-                ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
-        }
-    }
-    void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext* context)
-    {
-        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-            serializeContext->Class<CsvSpawnableAssetConfiguration>()
-                ->Version(1)
-                ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
-                ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
-                ->Field("PositionStdDev", &CsvSpawnableAssetConfiguration::m_positionStdDev)
-                ->Field("RotationStdDev", &CsvSpawnableAssetConfiguration::m_rotationStdDev)
-                ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
-                ->Field("PlaceOnTerrain", &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
-                ->Field("CollisionGroup", &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup);
+void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext *context) {
+  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
+    serializeContext->Class<CsvSpawnableEntityInfo>()
+        ->Version(1)
+        ->Field("Id", &CsvSpawnableEntityInfo::m_id)
+        ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
+        ->Field("Name", &CsvSpawnableEntityInfo::m_name)
+        ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
+  }
+}
+void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext *context) {
+  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
+    serializeContext->Class<CsvSpawnableAssetConfiguration>()
+        ->Version(1)
+        ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
+        ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
+        ->Field("PositionStdDev",
+                &CsvSpawnableAssetConfiguration::m_positionStdDev)
+        ->Field("RotationStdDev",
+                &CsvSpawnableAssetConfiguration::m_rotationStdDev)
+        ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
+        ->Field("PlaceOnTerrain",
+                &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
+        ->Field("CollisionGroup",
+                &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup);
 
-            if (auto* editContext = serializeContext->GetEditContext())
-            {
-                editContext->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration", "SpawnableAssetConfiguration")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "SpawnableAssetConfiguration")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_name, "Name", "Name of the spawnable field")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_spawnables, "Spawnables", "Vector of spawnables")
-                    ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern, "*.spawnable")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+    if (auto *editContext = serializeContext->GetEditContext()) {
+      editContext
+          ->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration",
+                                                  "SpawnableAssetConfiguration")
+          ->ClassElement(AZ::Edit::ClassElements::EditorData,
+                         "SpawnableAssetConfiguration")
+          ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu,
+                      AZ_CRC_CE("Game"))
+          ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
+          ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+          ->DataElement(AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_name, "Name",
+                        "Name of the spawnable field")
+          ->DataElement(AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_spawnables,
+                        "Spawnables", "Vector of spawnables")
+          ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern,
+                      "*.spawnable")
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_positionStdDev,
                         "Position Std. Dev.",
                         "Position standard deviation, in meters")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_rotationStdDev,
                         "Rotation Std. Dev. ",
                         "Rotation standard deviation, in degrees")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on Terrain",
                         "Perform scene query raytrace to place on terrain")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->Attribute(AZ::Edit::Attributes::ChangeNotify,
+                      &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_scaleStdDev,
                         "Scale Std. Dev.",
                         "Scale standard deviation, in meters")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup,
-                        "Collision Group",
-                        "To which collision group this target will be attached")
-                    ->Attribute(AZ::Edit::Attributes::ReadOnly, &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
-            }
-        }
+          ->DataElement(
+              AZ::Edit::UIHandlers::Default,
+              &CsvSpawnableAssetConfiguration::m_selectedCollisionGroup,
+              "Collision Group",
+              "To which collision group this target will be attached")
+          ->Attribute(AZ::Edit::Attributes::ReadOnly,
+                      &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
+    }
+  }
+}
+
+bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const {
+  return !m_placeOnTerrain;
+}
+
+AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged() {
+  return AZ::Edit::PropertyRefreshLevels::EntireTree;
+}
+
+AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+GetSpawnableAssetFromVector(AZStd::vector<CsvSpawnableAssetConfiguration>
+                                spawnableAssetConfigurations) {
+  AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+      spawnableAssetConfiguration;
+  for (auto &spawnableAssetConfigurationElement :
+       spawnableAssetConfigurations) {
+    spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] =
+        spawnableAssetConfigurationElement;
+  }
+  return spawnableAssetConfiguration;
+}
+
+template <typename T>
+T GetRandomElement(const AZStd::vector<T> &vec, std::mt19937 &gen) {
+  std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
+  return vec.at(distribution(gen));
+}
+
+AZ::Transform GetRandomTransform(const AZ::Vector3 &stdDevTranslation,
+                                 const AZ::Vector3 &stdDevRotation,
+                                 float stdDevScale, std::mt19937 &gen) {
+  AZ::Transform transform = AZ::Transform::CreateIdentity();
+  AZStd::vector<std::normal_distribution<float>> distributions;
+  distributions.emplace_back(0.0f, stdDevTranslation.GetX());
+  distributions.emplace_back(0.0f, stdDevTranslation.GetY());
+  distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
+  distributions.emplace_back(0.0f, stdDevRotation.GetX());
+  distributions.emplace_back(0.0f, stdDevRotation.GetY());
+  distributions.emplace_back(0.0f, stdDevRotation.GetZ());
+  distributions.emplace_back(1.0f, stdDevScale);
+
+  transform.SetTranslation(AZ::Vector3(
+      distributions[0](gen), distributions[1](gen), distributions[2](gen)));
+  const AZ::Quaternion rotation =
+      AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(
+          distributions[3](gen), distributions[4](gen), distributions[5](gen)));
+  transform.SetRotation(rotation);
+  transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
+  return transform;
+}
+
+AZStd::optional<AZ::Vector3>
+RaytraceTerrain(const AZ::Vector3 &location,
+                const AzPhysics::SceneHandle sceneHandle,
+                const AZ::Vector3 &gravityDirection, float maxDistance,
+                const AzPhysics::CollisionGroup &collisionGroup) {
+  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+  AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle,
+            "Unable to get  scene handle");
+  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
+    return hitPosition;
+  }
+
+  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+  AZ_Assert(physicsSystem, "Unable to get physics system interface");
+  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+  if (!sceneInterface || !physicsSystem) {
+    return hitPosition;
+  }
+
+  AzPhysics::RayCastRequest request;
+  request.m_start = location;
+  request.m_direction = gravityDirection;
+  request.m_distance = maxDistance;
+  request.m_collisionGroup = collisionGroup;
+
+  AzPhysics::SceneQueryHits result =
+      sceneInterface->QueryScene(sceneHandle, &request);
+
+  if (!result.m_hits.empty()) {
+    hitPosition = result.m_hits.front().m_position;
+  }
+
+  return hitPosition;
+}
+
+AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
+    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+        &spawnableAssetConfiguration,
+    AZ::u64 defaultSeed, const AZStd::string &physicsSceneName,
+    AZ::EntityId parentId) {
+  auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+  const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
+
+  AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
+  auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+  AZ_Assert(spawner, "Unable to get spawnable entities definition");
+
+  // get parent transform
+  AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
+  if (parentId.IsValid()) {
+    AZ::TransformBus::EventResult(parentTransform, parentId,
+                                  &AZ::TransformBus::Events::GetWorldTM);
+  }
+
+  for (auto &spawnables : spawnableAssetConfiguration) {
+    for (auto spawnable : spawnables.second.m_spawnables) {
+      spawnable.QueueLoad();
+    }
+  }
+
+  for (const auto &entityConfig : entitiesToSpawn) {
+    if (!spawnableAssetConfiguration.contains(entityConfig.m_name)) {
+      AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found",
+               entityConfig.m_name.c_str());
+      continue;
     }
 
-    bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const
-    {
-        return !m_placeOnTerrain;
+    const auto &spawnConfig =
+        spawnableAssetConfiguration.at(entityConfig.m_name);
+
+    // if seed is not set for this row, use the default seed
+    std::mt19937 gen = entityConfig.m_seed > 0
+                           ? std::mt19937(entityConfig.m_seed)
+                           : std::mt19937(defaultSeed++);
+
+    const auto &spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
+
+    AZ::Transform transform =
+        parentTransform * entityConfig.m_transform *
+        GetRandomTransform(spawnConfig.m_positionStdDev,
+                           spawnConfig.m_rotationStdDev,
+                           spawnConfig.m_scaleStdDev, gen);
+
+    if (spawnConfig.m_placeOnTerrain) {
+      // Get collision group chosen from editor
+      AzPhysics::CollisionGroup collisionGroup;
+      Physics::CollisionRequestBus::BroadcastResult(
+          collisionGroup, &Physics::CollisionRequests::GetCollisionGroupById,
+          spawnConfig.m_selectedCollisionGroup);
+
+      const AZStd::optional<AZ::Vector3> hitPosition =
+          RaytraceTerrain(transform.GetTranslation(), sceneHandle,
+                          -AZ::Vector3::CreateAxisZ(), 1000.0f, collisionGroup);
+
+      if (hitPosition.has_value()) {
+        transform.SetTranslation(hitPosition.value());
+      } else {
+        continue; // Skip this entity if we can't find a valid position and
+                  // place on terrain is enabled.
+      }
     }
+    AZ_Assert(spawner, "Unable to get spawnable entities definition");
+    AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+    AzFramework::EntitySpawnTicket ticket(spawnable);
+    // Set the pre-spawn callback to set the name of the root entity to the name
+    // of the spawnable
+    optionalArgs.m_preInsertionCallback = [transform](auto id, auto view) {
+      if (view.empty()) {
+        return;
+      }
+      AZ::Entity *root = *view.begin();
+      AZ_Assert(root, "Invalid root entity");
 
-    AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged()
-    {
-        return AZ::Edit::PropertyRefreshLevels::EntireTree;
-    }
-
-    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
-        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations)
-    {
-        AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> spawnableAssetConfiguration;
-        for (auto& spawnableAssetConfigurationElement : spawnableAssetConfigurations)
-        {
-            spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] = spawnableAssetConfigurationElement;
-        }
-        return spawnableAssetConfiguration;
-    }
-
-    template<typename T>
-    T GetRandomElement(const AZStd::vector<T>& vec, std::mt19937& gen)
-    {
-        std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
-        return vec.at(distribution(gen));
-    }
-
-    AZ::Transform GetRandomTransform(
-        const AZ::Vector3& stdDevTranslation, const AZ::Vector3& stdDevRotation, float stdDevScale, std::mt19937& gen)
-    {
-        AZ::Transform transform = AZ::Transform::CreateIdentity();
-        AZStd::vector<std::normal_distribution<float>> distributions;
-        distributions.emplace_back(0.0f, stdDevTranslation.GetX());
-        distributions.emplace_back(0.0f, stdDevTranslation.GetY());
-        distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
-        distributions.emplace_back(0.0f, stdDevRotation.GetX());
-        distributions.emplace_back(0.0f, stdDevRotation.GetY());
-        distributions.emplace_back(0.0f, stdDevRotation.GetZ());
-        distributions.emplace_back(1.0f, stdDevScale);
-
-        transform.SetTranslation(AZ::Vector3(distributions[0](gen), distributions[1](gen), distributions[2](gen)));
-        const AZ::Quaternion rotation =
-            AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(distributions[3](gen), distributions[4](gen), distributions[5](gen)));
-        transform.SetRotation(rotation);
-        transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
-        return transform;
-    }
-
-    AZStd::optional<AZ::Vector3> RaytraceTerrain(
-        const AZ::Vector3& location,
-        const AzPhysics::SceneHandle sceneHandle,
-        const AZ::Vector3& gravityDirection,
-        float maxDistance,
-        const AzPhysics::CollisionGroup& collisionGroup)
-    {
-        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
-        if (sceneHandle == AzPhysics::InvalidSceneHandle)
-        {
-            return hitPosition;
-        }
-
-        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(physicsSystem, "Unable to get physics system interface");
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-        if (!sceneInterface || !physicsSystem)
-        {
-            return hitPosition;
-        }
-
-        AzPhysics::RayCastRequest request;
-        request.m_start = location;
-        request.m_direction = gravityDirection;
-        request.m_distance = maxDistance;
-        request.m_collisionGroup = collisionGroup;
-
-        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
-
-        if (!result.m_hits.empty())
-        {
-            hitPosition = result.m_hits.front().m_position;
-        }
-
-        return hitPosition;
-    }
-
-    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
-        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
-        AZ::u64 defaultSeed,
-        const AZStd::string& physicsSceneName,
-        AZ::EntityId parentId)
-    {
-        auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-        const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
-
-        AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
-        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-        AZ_Assert(spawner, "Unable to get spawnable entities definition");
-
-        // get parent transform
-        AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
-        if (parentId.IsValid())
-        {
-            AZ::TransformBus::EventResult(parentTransform, parentId, &AZ::TransformBus::Events::GetWorldTM);
-        }
-
-        for (auto& spawnables : spawnableAssetConfiguration)
-        {
-            for (auto spawnable : spawnables.second.m_spawnables)
-            {
-                spawnable.QueueLoad();
-            }
-        }
-
-        for (const auto& entityConfig : entitiesToSpawn)
-        {
-            if (!spawnableAssetConfiguration.contains(entityConfig.m_name))
-            {
-                AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found", entityConfig.m_name.c_str());
-                continue;
-            }
-
-            const auto& spawnConfig = spawnableAssetConfiguration.at(entityConfig.m_name);
-
-            // if seed is not set for this row, use the default seed
-            std::mt19937 gen = entityConfig.m_seed > 0 ? std::mt19937(entityConfig.m_seed) : std::mt19937(defaultSeed++);
-
-            const auto& spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
-
-            AZ::Transform transform = parentTransform * entityConfig.m_transform *
-                GetRandomTransform(spawnConfig.m_positionStdDev, spawnConfig.m_rotationStdDev, spawnConfig.m_scaleStdDev, gen);
-
-            if (spawnConfig.m_placeOnTerrain)
-            {
-                // Get collision group chosen from editor
-                AzPhysics::CollisionGroup collisionGroup;
-                Physics::CollisionRequestBus::BroadcastResult(collisionGroup,
-                          &Physics::CollisionRequests::GetCollisionGroupById, spawnConfig.m_selectedCollisionGroup);
-
-                const AZStd::optional<AZ::Vector3> hitPosition = RaytraceTerrain(
-                    transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(), 1000.0f, collisionGroup);
-
-                if (hitPosition.has_value())
-                {
-                    transform.SetTranslation(hitPosition.value());
-                }
-                else
-                {
-                    continue; // Skip this entity if we can't find a valid position and
-                              // place on terrain is enabled.
-                }
-            }
-            AZ_Assert(spawner, "Unable to get spawnable entities definition");
-            AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-            AzFramework::EntitySpawnTicket ticket(spawnable);
-            // Set the pre-spawn callback to set the name of the root entity to the name
-            // of the spawnable
-            optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
-            {
-                if (view.empty())
-                {
-                    return;
-                }
-                AZ::Entity* root = *view.begin();
-                AZ_Assert(root, "Invalid root entity");
-
-                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
-                transformInterface->SetWorldTM(transform);
-            };
-            optionalArgs.m_completionCallback =
-                [parentId](
-                    [[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId, AzFramework::SpawnableConstEntityContainerView view)
-            {
-                if (view.empty())
-                {
-                    return;
-                }
-                const AZ::Entity* root = *view.begin();
-                AZ::TransformBus::Event(root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
-            };
-            optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
-            spawner->SpawnAllEntities(ticket, optionalArgs);
-            tickets[entityConfig.m_id] = AZStd::move(ticket);
-        }
-        return tickets;
-    }
+      auto *transformInterface =
+          root->FindComponent<AzFramework::TransformComponent>();
+      transformInterface->SetWorldTM(transform);
+    };
+    optionalArgs.m_completionCallback =
+        [parentId]([[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId,
+                   AzFramework::SpawnableConstEntityContainerView view) {
+          if (view.empty()) {
+            return;
+          }
+          const AZ::Entity *root = *view.begin();
+          AZ::TransformBus::Event(
+              root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
+        };
+    optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
+    spawner->SpawnAllEntities(ticket, optionalArgs);
+    tickets[entityConfig.m_id] = AZStd::move(ticket);
+  }
+  return tickets;
+}
 
 } // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -3,9 +3,10 @@
  *
  * This source code is protected under international copyright law.  All rights
  * reserved and protected by the copyright holders.
- * This file is confidential and only available to authorized individuals with the
- * permission of the copyright holders.  If you encounter this file and do not have
- * permission, please contact the copyright holders and delete this file.
+ * This file is confidential and only available to authorized individuals with
+ * the permission of the copyright holders.  If you encounter this file and do
+ * not have permission, please contact the copyright holders and delete this
+ * file.
  */
 
 #include "CsvSpawnerUtils.h"
@@ -23,291 +24,295 @@
 #include <cstdlib>
 #include <random>
 
-namespace CsvSpawner::CsvSpawnerUtils
-{
+namespace CsvSpawner::CsvSpawnerUtils {
 
-    void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext* context)
-    {
-        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-            serializeContext->Class<CsvSpawnableEntityInfo>()
-                ->Version(1)
-                ->Field("Id", &CsvSpawnableEntityInfo::m_id)
-                ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
-                ->Field("Name", &CsvSpawnableEntityInfo::m_name)
-                ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
-        }
-    }
-    void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext* context)
-    {
-        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
-        {
-            serializeContext->Class<CsvSpawnableAssetConfiguration>()
-                ->Version(1)
-                ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
-                ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
-                ->Field("PositionStdDev", &CsvSpawnableAssetConfiguration::m_positionStdDev)
-                ->Field("RotationStdDev", &CsvSpawnableAssetConfiguration::m_rotationStdDev)
-                ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
-                ->Field("PlaceOnTerrain", &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
-                ->Field("CollisionLayer", &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer);
+void CsvSpawnableEntityInfo::Reflect(AZ::ReflectContext *context) {
+  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
+    serializeContext->Class<CsvSpawnableEntityInfo>()
+        ->Version(1)
+        ->Field("Id", &CsvSpawnableEntityInfo::m_id)
+        ->Field("Transform", &CsvSpawnableEntityInfo::m_transform)
+        ->Field("Name", &CsvSpawnableEntityInfo::m_name)
+        ->Field("Seed", &CsvSpawnableEntityInfo::m_seed);
+  }
+}
+void CsvSpawnableAssetConfiguration::Reflect(AZ::ReflectContext *context) {
+  if (auto *serializeContext = azrtti_cast<AZ::SerializeContext *>(context)) {
+    serializeContext->Class<CsvSpawnableAssetConfiguration>()
+        ->Version(1)
+        ->Field("Name", &CsvSpawnableAssetConfiguration::m_name)
+        ->Field("Spawnable", &CsvSpawnableAssetConfiguration::m_spawnables)
+        ->Field("PositionStdDev",
+                &CsvSpawnableAssetConfiguration::m_positionStdDev)
+        ->Field("RotationStdDev",
+                &CsvSpawnableAssetConfiguration::m_rotationStdDev)
+        ->Field("ScaleStdDev", &CsvSpawnableAssetConfiguration::m_scaleStdDev)
+        ->Field("PlaceOnTerrain",
+                &CsvSpawnableAssetConfiguration::m_placeOnTerrain)
+        ->Field("CollisionLayer",
+                &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer);
 
-            if (auto* editContext = serializeContext->GetEditContext())
-            {
-                editContext->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration", "SpawnableAssetConfiguration")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "SpawnableAssetConfiguration")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
-                    ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_name, "Name", "Name of the spawnable field")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &CsvSpawnableAssetConfiguration::m_spawnables, "Spawnables", "Vector of spawnables")
-                    ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern, "*.spawnable")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+    if (auto *editContext = serializeContext->GetEditContext()) {
+      editContext
+          ->Class<CsvSpawnableAssetConfiguration>("SpawnableAssetConfiguration",
+                                                  "SpawnableAssetConfiguration")
+          ->ClassElement(AZ::Edit::ClassElements::EditorData,
+                         "SpawnableAssetConfiguration")
+          ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu,
+                      AZ_CRC_CE("Game"))
+          ->Attribute(AZ::Edit::Attributes::Category, "CsvSpawner")
+          ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+          ->DataElement(AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_name, "Name",
+                        "Name of the spawnable field")
+          ->DataElement(AZ::Edit::UIHandlers::Default,
+                        &CsvSpawnableAssetConfiguration::m_spawnables,
+                        "Spawnables", "Vector of spawnables")
+          ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern,
+                      "*.spawnable")
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_positionStdDev,
                         "Position Std. Dev.",
                         "Position standard deviation, in meters")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_rotationStdDev,
                         "Rotation Std. Dev. ",
                         "Rotation standard deviation, in degrees")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on Terrain",
                         "Perform scene query raytrace to place on terrain")
-                        ->Attribute(AZ::Edit::Attributes::ChangeNotify, &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default,
+          ->Attribute(AZ::Edit::Attributes::ChangeNotify,
+                      &CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged)
+          ->DataElement(AZ::Edit::UIHandlers::Default,
                         &CsvSpawnableAssetConfiguration::m_scaleStdDev,
                         "Scale Std. Dev.",
                         "Scale standard deviation, in meters")
-                    ->DataElement(AZ::Edit::UIHandlers::Default,
-                        &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer,
-                        "Collision Layer",
-                        "To which collision layer this target will be attached")
-                        ->Attribute(AZ::Edit::Attributes::ReadOnly, &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
-            }
-        }
+          ->DataElement(
+              AZ::Edit::UIHandlers::Default,
+              &CsvSpawnableAssetConfiguration::m_selectedCollisionLayer,
+              "Collision Layer",
+              "To which collision layer this target will be attached")
+          ->Attribute(AZ::Edit::Attributes::ReadOnly,
+                      &CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled);
+    }
+  }
+}
+
+bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const {
+  return !m_placeOnTerrain;
+}
+
+AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged() {
+  return AZ::Edit::PropertyRefreshLevels::EntireTree;
+}
+
+AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+GetSpawnableAssetFromVector(AZStd::vector<CsvSpawnableAssetConfiguration>
+                                spawnableAssetConfigurations) {
+  AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+      spawnableAssetConfiguration;
+  for (auto &spawnableAssetConfigurationElement :
+       spawnableAssetConfigurations) {
+    spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] =
+        spawnableAssetConfigurationElement;
+  }
+  return spawnableAssetConfiguration;
+}
+
+template <typename T>
+T GetRandomElement(const AZStd::vector<T> &vec, std::mt19937 &gen) {
+  std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
+  return vec.at(distribution(gen));
+}
+
+AZ::Transform GetRandomTransform(const AZ::Vector3 &stdDevTranslation,
+                                 const AZ::Vector3 &stdDevRotation,
+                                 float stdDevScale, std::mt19937 &gen) {
+  AZ::Transform transform = AZ::Transform::CreateIdentity();
+  AZStd::vector<std::normal_distribution<float>> distributions;
+  distributions.emplace_back(0.0f, stdDevTranslation.GetX());
+  distributions.emplace_back(0.0f, stdDevTranslation.GetY());
+  distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
+  distributions.emplace_back(0.0f, stdDevRotation.GetX());
+  distributions.emplace_back(0.0f, stdDevRotation.GetY());
+  distributions.emplace_back(0.0f, stdDevRotation.GetZ());
+  distributions.emplace_back(1.0f, stdDevScale);
+
+  transform.SetTranslation(AZ::Vector3(
+      distributions[0](gen), distributions[1](gen), distributions[2](gen)));
+  const AZ::Quaternion rotation =
+      AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(
+          distributions[3](gen), distributions[4](gen), distributions[5](gen)));
+  transform.SetRotation(rotation);
+  transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
+  return transform;
+}
+
+AZStd::optional<AZ::Vector3>
+RaytraceTerrain(const AZ::Vector3 &location,
+                const AzPhysics::SceneHandle sceneHandle,
+                const AZ::Vector3 &gravityDirection, float maxDistance) {
+  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
+    return hitPosition;
+  }
+
+  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+  AZ_Assert(physicsSystem, "Unable to get physics system interface");
+  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+  if (!sceneInterface || !physicsSystem) {
+    return hitPosition;
+  }
+
+  AzPhysics::RayCastRequest request;
+  request.m_start = location;
+  request.m_direction = gravityDirection;
+  request.m_distance = maxDistance;
+
+  AzPhysics::SceneQueryHits result =
+      sceneInterface->QueryScene(sceneHandle, &request);
+
+  if (!result.m_hits.empty()) {
+    hitPosition = result.m_hits.front().m_position;
+  }
+
+  return hitPosition;
+}
+
+AZStd::optional<AZ::Vector3>
+RaytraceTerrain(const AZ::Vector3 &location,
+                const AzPhysics::SceneHandle sceneHandle,
+                const AZ::Vector3 &gravityDirection, float maxDistance,
+                AzPhysics::CollisionLayer collisionLayer) {
+  AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
+
+  AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle,
+            "Unable to get  scene handle");
+  if (sceneHandle == AzPhysics::InvalidSceneHandle) {
+    return hitPosition;
+  }
+
+  auto *physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
+  auto *sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+  AZ_Assert(physicsSystem, "Unable to get physics system interface");
+  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+
+  if (!sceneInterface || !physicsSystem) {
+    return hitPosition;
+  }
+
+  AzPhysics::RayCastRequest request;
+  request.m_start = location;
+  request.m_direction = gravityDirection;
+  request.m_distance = maxDistance;
+  request.m_collisionGroup.SetLayer(collisionLayer, true);
+
+  AzPhysics::SceneQueryHits result =
+      sceneInterface->QueryScene(sceneHandle, &request);
+
+  if (!result.m_hits.empty()) {
+    hitPosition = result.m_hits.front().m_position;
+  }
+
+  return hitPosition;
+}
+
+AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
+    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+        &spawnableAssetConfiguration,
+    AZ::u64 defaultSeed, const AZStd::string &physicsSceneName,
+    AZ::EntityId parentId) {
+  auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
+  AZ_Assert(sceneInterface, "Unable to get physics scene interface");
+  const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
+
+  AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
+  auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
+  AZ_Assert(spawner, "Unable to get spawnable entities definition");
+
+  // get parent transform
+  AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
+  if (parentId.IsValid()) {
+    AZ::TransformBus::EventResult(parentTransform, parentId,
+                                  &AZ::TransformBus::Events::GetWorldTM);
+  }
+
+  for (auto &spawnables : spawnableAssetConfiguration) {
+    for (auto spawnable : spawnables.second.m_spawnables) {
+      spawnable.QueueLoad();
+    }
+  }
+
+  for (const auto &entityConfig : entitiesToSpawn) {
+    if (!spawnableAssetConfiguration.contains(entityConfig.m_name)) {
+      AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found",
+               entityConfig.m_name.c_str());
+      continue;
     }
 
-    bool CsvSpawnableAssetConfiguration::IsCollisionLayerEnabled() const
-    {
-        return !m_placeOnTerrain;
+    const auto &spawnConfig =
+        spawnableAssetConfiguration.at(entityConfig.m_name);
+
+    // if seed is not set for this row, use the default seed
+    std::mt19937 gen = entityConfig.m_seed > 0
+                           ? std::mt19937(entityConfig.m_seed)
+                           : std::mt19937(defaultSeed++);
+
+    const auto &spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
+
+    AZ::Transform transform =
+        parentTransform * entityConfig.m_transform *
+        GetRandomTransform(spawnConfig.m_positionStdDev,
+                           spawnConfig.m_rotationStdDev,
+                           spawnConfig.m_scaleStdDev, gen);
+
+    if (spawnConfig.m_placeOnTerrain) {
+      const AZStd::optional<AZ::Vector3> hitPosition = RaytraceTerrain(
+          transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(),
+          1000.0f, spawnConfig.m_selectedCollisionLayer);
+      if (hitPosition.has_value()) {
+        transform.SetTranslation(hitPosition.value());
+      } else {
+        continue; // Skip this entity if we can't find a valid position and
+                  // place on terrain is enabled.
+      }
     }
+    AZ_Assert(spawner, "Unable to get spawnable entities definition");
+    AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
+    AzFramework::EntitySpawnTicket ticket(spawnable);
+    // Set the pre-spawn callback to set the name of the root entity to the name
+    // of the spawnable
+    optionalArgs.m_preInsertionCallback = [transform](auto id, auto view) {
+      if (view.empty()) {
+        return;
+      }
+      AZ::Entity *root = *view.begin();
+      AZ_Assert(root, "Invalid root entity");
 
-    AZ::Crc32 CsvSpawnableAssetConfiguration::OnPlaceOnTerrainChanged()
-    {
-        return AZ::Edit::PropertyRefreshLevels::EntireTree;
-    }
-
-    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
-        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations)
-    {
-        AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> spawnableAssetConfiguration;
-        for (auto& spawnableAssetConfigurationElement : spawnableAssetConfigurations)
-        {
-            spawnableAssetConfiguration[spawnableAssetConfigurationElement.m_name] = spawnableAssetConfigurationElement;
-        }
-        return spawnableAssetConfiguration;
-    }
-
-    template<typename T>
-    T GetRandomElement(const AZStd::vector<T>& vec, std::mt19937& gen)
-    {
-        std::uniform_int_distribution<int> distribution(0, vec.size() - 1);
-        return vec.at(distribution(gen));
-    }
-
-    AZ::Transform GetRandomTransform(
-        const AZ::Vector3& stdDevTranslation, const AZ::Vector3& stdDevRotation, float stdDevScale, std::mt19937& gen)
-    {
-        AZ::Transform transform = AZ::Transform::CreateIdentity();
-        AZStd::vector<std::normal_distribution<float>> distributions;
-        distributions.emplace_back(0.0f, stdDevTranslation.GetX());
-        distributions.emplace_back(0.0f, stdDevTranslation.GetY());
-        distributions.emplace_back(0.0f, stdDevTranslation.GetZ());
-        distributions.emplace_back(0.0f, stdDevRotation.GetX());
-        distributions.emplace_back(0.0f, stdDevRotation.GetY());
-        distributions.emplace_back(0.0f, stdDevRotation.GetZ());
-        distributions.emplace_back(1.0f, stdDevScale);
-
-        transform.SetTranslation(AZ::Vector3(distributions[0](gen), distributions[1](gen), distributions[2](gen)));
-        const AZ::Quaternion rotation =
-            AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(distributions[3](gen), distributions[4](gen), distributions[5](gen)));
-        transform.SetRotation(rotation);
-        transform.SetUniformScale(AZStd::max(0.0f, distributions[6](gen)));
-        return transform;
-    }
-
-    AZStd::optional<AZ::Vector3> RaytraceTerrain(
-        const AZ::Vector3& location, const AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& gravityDirection, float maxDistance)
-    {
-        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-        if (sceneHandle == AzPhysics::InvalidSceneHandle)
-        {
-            return hitPosition;
-        }
-
-        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(physicsSystem, "Unable to get physics system interface");
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-        if (!sceneInterface || !physicsSystem)
-        {
-            return hitPosition;
-        }
-
-        AzPhysics::RayCastRequest request;
-        request.m_start = location;
-        request.m_direction = gravityDirection;
-        request.m_distance = maxDistance;
-
-        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
-
-        if (!result.m_hits.empty())
-        {
-            hitPosition = result.m_hits.front().m_position;
-        }
-
-        return hitPosition;
-    }
-
-    AZStd::optional<AZ::Vector3> RaytraceTerrain(
-        const AZ::Vector3& location, const AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& gravityDirection, float maxDistance, AzPhysics::CollisionLayer collisionLayer)
-    {
-        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
-        if (sceneHandle == AzPhysics::InvalidSceneHandle)
-        {
-            return hitPosition;
-        }
-
-        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(physicsSystem, "Unable to get physics system interface");
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-        if (!sceneInterface || !physicsSystem)
-        {
-            return hitPosition;
-        }
-
-        AzPhysics::RayCastRequest request;
-        request.m_start = location;
-        request.m_direction = gravityDirection;
-        request.m_distance = maxDistance;
-        request.m_collisionGroup.SetLayer(collisionLayer, true);
-
-        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
-
-        if (!result.m_hits.empty())
-        {
-            hitPosition = result.m_hits.front().m_position;
-        }
-
-        return hitPosition;
-    }
-
-    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
-        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
-        AZ::u64 defaultSeed,
-        const AZStd::string& physicsSceneName,
-        AZ::EntityId parentId)
-    {
-        auto sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-        const auto sceneHandle = sceneInterface->GetSceneHandle(physicsSceneName);
-
-        AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> tickets{};
-        auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
-        AZ_Assert(spawner, "Unable to get spawnable entities definition");
-
-        // get parent transform
-        AZ::Transform parentTransform = AZ::Transform::CreateIdentity();
-        if (parentId.IsValid())
-        {
-            AZ::TransformBus::EventResult(parentTransform, parentId, &AZ::TransformBus::Events::GetWorldTM);
-        }
-
-        for (auto& spawnables : spawnableAssetConfiguration)
-        {
-            for (auto spawnable : spawnables.second.m_spawnables)
-            {
-                spawnable.QueueLoad();
-            }
-        }
-
-        for (const auto& entityConfig : entitiesToSpawn)
-        {
-            if (!spawnableAssetConfiguration.contains(entityConfig.m_name))
-            {
-                AZ_Error("CsvSpawner", false, "SpawnableAssetConfiguration %s not found", entityConfig.m_name.c_str());
-                continue;
-            }
-
-            const auto& spawnConfig = spawnableAssetConfiguration.at(entityConfig.m_name);
-
-            // if seed is not set for this row, use the default seed
-            std::mt19937 gen = entityConfig.m_seed > 0 ? std::mt19937(entityConfig.m_seed) : std::mt19937(defaultSeed++);
-
-            const auto& spawnable = GetRandomElement(spawnConfig.m_spawnables, gen);
-
-            AZ::Transform transform = parentTransform * entityConfig.m_transform *
-                GetRandomTransform(spawnConfig.m_positionStdDev, spawnConfig.m_rotationStdDev, spawnConfig.m_scaleStdDev, gen);
-
-            if (spawnConfig.m_placeOnTerrain)
-            {
-                const AZStd::optional<AZ::Vector3> hitPosition =
-                    RaytraceTerrain(transform.GetTranslation(), sceneHandle, -AZ::Vector3::CreateAxisZ(), 1000.0f, spawnConfig.m_selectedCollisionLayer);
-                if (hitPosition.has_value())
-                {
-                    transform.SetTranslation(hitPosition.value());
-                }
-                else
-                {
-                    continue; // Skip this entity if we can't find a valid position and place on terrain is enabled.
-                }
-            }
-            AZ_Assert(spawner, "Unable to get spawnable entities definition");
-            AzFramework::SpawnAllEntitiesOptionalArgs optionalArgs;
-            AzFramework::EntitySpawnTicket ticket(spawnable);
-            // Set the pre-spawn callback to set the name of the root entity to the name of the spawnable
-            optionalArgs.m_preInsertionCallback = [transform](auto id, auto view)
-            {
-                if (view.empty())
-                {
-                    return;
-                }
-                AZ::Entity* root = *view.begin();
-                AZ_Assert(root, "Invalid root entity");
-
-                auto* transformInterface = root->FindComponent<AzFramework::TransformComponent>();
-                transformInterface->SetWorldTM(transform);
-            };
-            optionalArgs.m_completionCallback =
-                [parentId](
-                    [[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId, AzFramework::SpawnableConstEntityContainerView view)
-            {
-                if (view.empty())
-                {
-                    return;
-                }
-                const AZ::Entity* root = *view.begin();
-                AZ::TransformBus::Event(root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
-            };
-            optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
-            spawner->SpawnAllEntities(ticket, optionalArgs);
-            tickets[entityConfig.m_id] = AZStd::move(ticket);
-        }
-        return tickets;
-    }
+      auto *transformInterface =
+          root->FindComponent<AzFramework::TransformComponent>();
+      transformInterface->SetWorldTM(transform);
+    };
+    optionalArgs.m_completionCallback =
+        [parentId]([[maybe_unused]] AzFramework::EntitySpawnTicket::Id ticketId,
+                   AzFramework::SpawnableConstEntityContainerView view) {
+          if (view.empty()) {
+            return;
+          }
+          const AZ::Entity *root = *view.begin();
+          AZ::TransformBus::Event(
+              root->GetId(), &AZ::TransformBus::Events::SetParent, parentId);
+        };
+    optionalArgs.m_priority = AzFramework::SpawnablePriority_Lowest;
+    spawner->SpawnAllEntities(ticket, optionalArgs);
+    tickets[entityConfig.m_id] = AZStd::move(ticket);
+  }
+  return tickets;
+}
 
 } // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -149,41 +149,6 @@ namespace CsvSpawner::CsvSpawnerUtils
     }
 
     AZStd::optional<AZ::Vector3> RaytraceTerrain(
-        const AZ::Vector3& location, const AzPhysics::SceneHandle sceneHandle, const AZ::Vector3& gravityDirection, float maxDistance)
-    {
-        AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
-
-        if (sceneHandle == AzPhysics::InvalidSceneHandle)
-        {
-            return hitPosition;
-        }
-
-        auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get();
-        auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
-        AZ_Assert(physicsSystem, "Unable to get physics system interface");
-        AZ_Assert(sceneInterface, "Unable to get physics scene interface");
-
-        if (!sceneInterface || !physicsSystem)
-        {
-            return hitPosition;
-        }
-
-        AzPhysics::RayCastRequest request;
-        request.m_start = location;
-        request.m_direction = gravityDirection;
-        request.m_distance = maxDistance;
-
-        AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
-
-        if (!result.m_hits.empty())
-        {
-            hitPosition = result.m_hits.front().m_position;
-        }
-
-        return hitPosition;
-    }
-
-    AZStd::optional<AZ::Vector3> RaytraceTerrain(
         const AZ::Vector3& location,
         const AzPhysics::SceneHandle sceneHandle,
         const AZ::Vector3& gravityDirection,

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "AzFramework/Physics/Collision/CollisionLayers.h"
 #include "CsvSpawner/CsvSpawnerTypeIds.h"
 
 #include <AzCore/Asset/AssetCommon.h>

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -21,83 +21,81 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace CsvSpawner::CsvSpawnerUtils {
+namespace CsvSpawner::CsvSpawnerUtils
+{
 
-//! Information about a locations to spawn an entity.
-//! This information is generated from CSV file and is used to spawn the entity.
-//! @param m_name is the name of the spawnable entity configuration and should
-//! be identical to name in @class SpawnableAssetConfiguration.
-class CsvSpawnableEntityInfo {
-public:
-  AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
-  static void Reflect(AZ::ReflectContext *context);
-  CsvSpawnableEntityInfo() = default;
-  virtual ~CsvSpawnableEntityInfo() = default;
+    //! Information about a locations to spawn an entity.
+    //! This information is generated from CSV file and is used to spawn the entity.
+    //! @param m_name is the name of the spawnable entity configuration and should
+    //! be identical to name in @class SpawnableAssetConfiguration.
+    class CsvSpawnableEntityInfo
+    {
+    public:
+        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+        CsvSpawnableEntityInfo() = default;
+        virtual ~CsvSpawnableEntityInfo() = default;
 
-  unsigned int m_id;         //!< Optional ID for the entity
-  AZ::Transform m_transform; //!< Transform of the entity, mandatory
-  AZStd::string
-      m_name;         //!< Name of the spawnable entity configuration, mandatory
-  uint64_t m_seed{0}; //!< Optional seed value for randomization, in the context
-                      //!< of one spawnable entity configuration, optional
-};
+        unsigned int m_id; //!< Optional ID for the entity
+        AZ::Transform m_transform; //!< Transform of the entity, mandatory
+        AZStd::string m_name; //!< Name of the spawnable entity configuration, mandatory
+        uint64_t m_seed{ 0 }; //!< Optional seed value for randomization, in the context
+                              //!< of one spawnable entity configuration, optional
+    };
 
-//! Configuration for a spawnable asset
-//! This configuration is used to configure the spawnable asset before spawning
-//! it. The @param m_name is used to identify the spawnable asset configuration
-//! and should be identical to name given in CSV file. The class allows user to
-//! specify multiple spawnable assets for a given name and randomization
-//! parameters for position, rotation and scale. If more then one spawnable
-//! asset is specified for a given name, then one of the spawnable assets is
-//! randomly selected for spawning.
-class CsvSpawnableAssetConfiguration {
-public:
-  AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
-  static void Reflect(AZ::ReflectContext *context);
-  CsvSpawnableAssetConfiguration() = default;
-  virtual ~CsvSpawnableAssetConfiguration() = default;
+    //! Configuration for a spawnable asset
+    //! This configuration is used to configure the spawnable asset before spawning
+    //! it. The @param m_name is used to identify the spawnable asset configuration
+    //! and should be identical to name given in CSV file. The class allows user to
+    //! specify multiple spawnable assets for a given name and randomization
+    //! parameters for position, rotation and scale. If more then one spawnable
+    //! asset is specified for a given name, then one of the spawnable assets is
+    //! randomly selected for spawning.
+    class CsvSpawnableAssetConfiguration
+    {
+    public:
+        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+        CsvSpawnableAssetConfiguration() = default;
+        virtual ~CsvSpawnableAssetConfiguration() = default;
 
-  AZStd::string m_name; //!< Name of the spawnable field
-  AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>>
-      m_spawnables;                  //!< List of spawnable assets
-  AZ::Vector3 m_positionStdDev{0.f}; //!< Standard deviation for position
-  AZ::Vector3 m_rotationStdDev{0.f}; //!< Standard deviation for rotation
-  float m_scaleStdDev{0.1f};         //!< Standard deviation for scale
-  bool m_placeOnTerrain{false}; //!< Whether to raytrace to terrain and place
-                                //!< the entity on the terrain
-  AzPhysics::CollisionLayer
-      m_selectedCollisionLayer; //!< To which collision layer this target will
-                                //!< be attached
+        AZStd::string m_name; //!< Name of the spawnable field
+        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
+        AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
+        AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
+        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
+        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place
+                                        //!< the entity on the terrain
+        AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will
+                                                            //!< be attached
 
-private:
-  [[nodiscard]] bool IsCollisionLayerEnabled() const;
-  static AZ::Crc32 OnPlaceOnTerrainChanged();
-};
+    private:
+        [[nodiscard]] bool IsCollisionLayerEnabled() const;
+        static AZ::Crc32 OnPlaceOnTerrainChanged();
+    };
 
-//! This function create map of spawnable asset configuration from vector of
-//! spawnable asset configuration, where the key is the name of the spawnable
-//! asset configuration
-//! @param spawnableAssetConfigurations - vector of spawnable asset
-//! configuration
-//! @return map of spawnable asset configuration
-AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-GetSpawnableAssetFromVector(
-    AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
+    //! This function create map of spawnable asset configuration from vector of
+    //! spawnable asset configuration, where the key is the name of the spawnable
+    //! asset configuration
+    //! @param spawnableAssetConfigurations - vector of spawnable asset
+    //! configuration
+    //! @return map of spawnable asset configuration
+    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
+        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
 
-//! Spawn entities from the vector of spawnable entity info
-//! @param entitiesToSpawn - vector of spawnable entity info
-//! @param spawnableAssetConfiguration - map of spawnable asset configuration
-//! @param defaultSeed - default seed value
-//! @param parentId - parent entity id to set for new entities
-//! @param physicsSceneName - physics scene name
-//! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
-//! @return map of spawn created tickets
-AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
-    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-        &spawnableAssetConfiguration,
-    const AZ::u64 defaultSeed,
-    const AZStd::string &physicsSceneName = AZStd::string(),
-    AZ::EntityId parentId = AZ::EntityId());
+    //! Spawn entities from the vector of spawnable entity info
+    //! @param entitiesToSpawn - vector of spawnable entity info
+    //! @param spawnableAssetConfiguration - map of spawnable asset configuration
+    //! @param defaultSeed - default seed value
+    //! @param parentId - parent entity id to set for new entities
+    //! @param physicsSceneName - physics scene name
+    //! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
+    //! @return map of spawn created tickets
+    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
+        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
+        const AZ::u64 defaultSeed,
+        const AZStd::string& physicsSceneName = AZStd::string(),
+        AZ::EntityId parentId = AZ::EntityId());
 
 }; // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -64,8 +64,8 @@ namespace CsvSpawner::CsvSpawnerUtils
 		AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will be attached
 
     private:
-        bool IsCollisionLayerEnabled() const;
-        AZ::Crc32 OnPlaceOnTerrainChanged();
+        [[nodiscard]] bool IsCollisionLayerEnabled() const;
+        static AZ::Crc32 OnPlaceOnTerrainChanged();
     };
 
     //! This function create map of spawnable asset configuration from vector of spawnable asset configuration, where

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "AzFramework/Physics/Collision/CollisionGroups.h"
 #include "AzFramework/Physics/Collision/CollisionLayers.h"
 #include "CsvSpawner/CsvSpawnerTypeIds.h"
 
@@ -66,7 +67,7 @@ namespace CsvSpawner::CsvSpawnerUtils
         float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
         bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place
                                         //!< the entity on the terrain
-        AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will
+        AzPhysics::CollisionGroups::Id m_selectedCollisionGroup; //!< To which collision group this target will
                                                             //!< be attached
 
     private:

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -22,83 +22,81 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace CsvSpawner::CsvSpawnerUtils {
+namespace CsvSpawner::CsvSpawnerUtils
+{
 
-//! Information about a locations to spawn an entity.
-//! This information is generated from CSV file and is used to spawn the entity.
-//! @param m_name is the name of the spawnable entity configuration and should
-//! be identical to name in @class SpawnableAssetConfiguration.
-class CsvSpawnableEntityInfo {
-public:
-  AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
-  static void Reflect(AZ::ReflectContext *context);
-  CsvSpawnableEntityInfo() = default;
-  virtual ~CsvSpawnableEntityInfo() = default;
+    //! Information about a locations to spawn an entity.
+    //! This information is generated from CSV file and is used to spawn the entity.
+    //! @param m_name is the name of the spawnable entity configuration and should
+    //! be identical to name in @class SpawnableAssetConfiguration.
+    class CsvSpawnableEntityInfo
+    {
+    public:
+        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+        CsvSpawnableEntityInfo() = default;
+        virtual ~CsvSpawnableEntityInfo() = default;
 
-  unsigned int m_id;         //!< Optional ID for the entity
-  AZ::Transform m_transform; //!< Transform of the entity, mandatory
-  AZStd::string
-      m_name;         //!< Name of the spawnable entity configuration, mandatory
-  uint64_t m_seed{0}; //!< Optional seed value for randomization, in the context
-                      //!< of one spawnable entity configuration, optional
-};
+        unsigned int m_id; //!< Optional ID for the entity
+        AZ::Transform m_transform; //!< Transform of the entity, mandatory
+        AZStd::string m_name; //!< Name of the spawnable entity configuration, mandatory
+        uint64_t m_seed{ 0 }; //!< Optional seed value for randomization, in the context
+                              //!< of one spawnable entity configuration, optional
+    };
 
-//! Configuration for a spawnable asset
-//! This configuration is used to configure the spawnable asset before spawning
-//! it. The @param m_name is used to identify the spawnable asset configuration
-//! and should be identical to name given in CSV file. The class allows user to
-//! specify multiple spawnable assets for a given name and randomization
-//! parameters for position, rotation and scale. If more then one spawnable
-//! asset is specified for a given name, then one of the spawnable assets is
-//! randomly selected for spawning.
-class CsvSpawnableAssetConfiguration {
-public:
-  AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
-  static void Reflect(AZ::ReflectContext *context);
-  CsvSpawnableAssetConfiguration() = default;
-  virtual ~CsvSpawnableAssetConfiguration() = default;
+    //! Configuration for a spawnable asset
+    //! This configuration is used to configure the spawnable asset before spawning
+    //! it. The @param m_name is used to identify the spawnable asset configuration
+    //! and should be identical to name given in CSV file. The class allows user to
+    //! specify multiple spawnable assets for a given name and randomization
+    //! parameters for position, rotation and scale. If more then one spawnable
+    //! asset is specified for a given name, then one of the spawnable assets is
+    //! randomly selected for spawning.
+    class CsvSpawnableAssetConfiguration
+    {
+    public:
+        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+        CsvSpawnableAssetConfiguration() = default;
+        virtual ~CsvSpawnableAssetConfiguration() = default;
 
-  AZStd::string m_name; //!< Name of the spawnable field
-  AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>>
-      m_spawnables;                  //!< List of spawnable assets
-  AZ::Vector3 m_positionStdDev{0.f}; //!< Standard deviation for position
-  AZ::Vector3 m_rotationStdDev{0.f}; //!< Standard deviation for rotation
-  float m_scaleStdDev{0.1f};         //!< Standard deviation for scale
-  bool m_placeOnTerrain{false}; //!< Whether to raytrace to terrain and place
-                                //!< the entity on the terrain
-  AzPhysics::CollisionGroups::Id
-      m_selectedCollisionGroup; //!< To which collision group this target will
-                                //!< be attached
+        AZStd::string m_name; //!< Name of the spawnable field
+        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
+        AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
+        AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
+        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
+        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place
+                                        //!< the entity on the terrain
+        AzPhysics::CollisionGroups::Id m_selectedCollisionGroup; //!< To which collision group this target will
+                                                                 //!< be attached
 
-private:
-  [[nodiscard]] bool IsCollisionLayerEnabled() const;
-  static AZ::Crc32 OnPlaceOnTerrainChanged();
-};
+    private:
+        [[nodiscard]] bool IsCollisionLayerEnabled() const;
+        static AZ::Crc32 OnPlaceOnTerrainChanged();
+    };
 
-//! This function create map of spawnable asset configuration from vector of
-//! spawnable asset configuration, where the key is the name of the spawnable
-//! asset configuration
-//! @param spawnableAssetConfigurations - vector of spawnable asset
-//! configuration
-//! @return map of spawnable asset configuration
-AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-GetSpawnableAssetFromVector(
-    AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
+    //! This function create map of spawnable asset configuration from vector of
+    //! spawnable asset configuration, where the key is the name of the spawnable
+    //! asset configuration
+    //! @param spawnableAssetConfigurations - vector of spawnable asset
+    //! configuration
+    //! @return map of spawnable asset configuration
+    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
+        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
 
-//! Spawn entities from the vector of spawnable entity info
-//! @param entitiesToSpawn - vector of spawnable entity info
-//! @param spawnableAssetConfiguration - map of spawnable asset configuration
-//! @param defaultSeed - default seed value
-//! @param parentId - parent entity id to set for new entities
-//! @param physicsSceneName - physics scene name
-//! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
-//! @return map of spawn created tickets
-AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
-    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
-        &spawnableAssetConfiguration,
-    const AZ::u64 defaultSeed,
-    const AZStd::string &physicsSceneName = AZStd::string(),
-    AZ::EntityId parentId = AZ::EntityId());
+    //! Spawn entities from the vector of spawnable entity info
+    //! @param entitiesToSpawn - vector of spawnable entity info
+    //! @param spawnableAssetConfiguration - map of spawnable asset configuration
+    //! @param defaultSeed - default seed value
+    //! @param parentId - parent entity id to set for new entities
+    //! @param physicsSceneName - physics scene name
+    //! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
+    //! @return map of spawn created tickets
+    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
+        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
+        const AZ::u64 defaultSeed,
+        const AZStd::string& physicsSceneName = AZStd::string(),
+        AZ::EntityId parentId = AZ::EntityId());
 
 }; // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -1,35 +1,36 @@
 /**
- * Copyright (C) Robotec AI - All Rights Reserved
- *
- * This source code is protected under international copyright law.  All rights
- * reserved and protected by the copyright holders.
- * This file is confidential and only available to authorized individuals with the
- * permission of the copyright holders.  If you encounter this file and do not have
- * permission, please contact the copyright holders and delete this file.
- */
+* Copyright (C) Robotec AI - All Rights Reserved
+*
+* This source code is protected under international copyright law.  All rights
+* reserved and protected by the copyright holders.
+* This file is confidential and only available to authorized individuals with the
+* permission of the copyright holders.  If you encounter this file and do not have
+* permission, please contact the copyright holders and delete this file.
+*/
 
 #pragma once
 
-#include "CsvSpawner/CsvSpawnerTypeIds.h"
+#include "AzFramework/Physics/Collision/CollisionLayers.h"
+#include "AzFramework/Physics/Common/PhysicsEvents.h"
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string.h>
+#include <AzFramework/Physics/PropertyTypes.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace CsvSpawner::CsvSpawnerUtils
+namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
 {
 
     //! Information about a locations to spawn an entity.
     //! This information is generated from CSV file and is used to spawn the entity.
-    //! @param m_name is the name of the spawnable entity configuration and should be identical to name in @class
-    //! SpawnableAssetConfiguration.
+    //! @param m_name is the name of the spawnable entity configuration and should be identical to name in @class SpawnableAssetConfiguration.
     class CsvSpawnableEntityInfo
     {
     public:
-        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
+        AZ_RTTI(CsvSpawnableEntityInfo, "{6acce47e-9cac-4a6e-8726-ea614fb2d30d}");
         static void Reflect(AZ::ReflectContext* context);
         CsvSpawnableEntityInfo() = default;
         virtual ~CsvSpawnableEntityInfo() = default;
@@ -43,13 +44,12 @@ namespace CsvSpawner::CsvSpawnerUtils
     //! Configuration for a spawnable asset
     //! This configuration is used to configure the spawnable asset before spawning it.
     //! The @param m_name is used to identify the spawnable asset configuration and should be identical to name given in CSV file.
-    //! The class allows user to specify multiple spawnable assets for a given name and randomization parameters for position, rotation and
-    //! scale. If more then one spawnable asset is specified for a given name, then one of the spawnable assets is randomly selected for
-    //! spawning.
+    //! The class allows user to specify multiple spawnable assets for a given name and randomization parameters for position, rotation and scale.
+    //! If more then one spawnable asset is specified for a given name, then one of the spawnable assets is randomly selected for spawning.
     class CsvSpawnableAssetConfiguration
     {
     public:
-        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
+        AZ_RTTI(CsvSpawnableAssetConfiguration, "{d04ea4de-b4dc-4e76-b742-c1d77203bc3e}");
         static void Reflect(AZ::ReflectContext* context);
         CsvSpawnableAssetConfiguration() = default;
         virtual ~CsvSpawnableAssetConfiguration() = default;
@@ -58,8 +58,13 @@ namespace CsvSpawner::CsvSpawnerUtils
         AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
         AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
         AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
-        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
-        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place the entity on the terrain
+        float m_scaleStdDev { 0.1f }; //!< Standard deviation for scale
+        bool m_placeOnTerrain { false }; //!< Whether to raytrace to terrain and place the entity on the terrain
+        AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will be attached
+
+    private:
+        bool bIsCollisionLayerEnabled() const;
+        AZ::Crc32 OnPlaceOnTerrainChanged();
     };
 
     //! This function create map of spawnable asset configuration from vector of spawnable asset configuration, where
@@ -83,4 +88,4 @@ namespace CsvSpawner::CsvSpawnerUtils
         const AZStd::string& physicsSceneName = AZStd::string(),
         AZ::EntityId parentId = AZ::EntityId());
 
-}; // namespace CsvSpawner::CsvSpawnerUtils
+}; // namespace RobotecEnvironmentSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -1,36 +1,35 @@
 /**
-* Copyright (C) Robotec AI - All Rights Reserved
-*
-* This source code is protected under international copyright law.  All rights
-* reserved and protected by the copyright holders.
-* This file is confidential and only available to authorized individuals with the
-* permission of the copyright holders.  If you encounter this file and do not have
-* permission, please contact the copyright holders and delete this file.
-*/
+ * Copyright (C) Robotec AI - All Rights Reserved
+ *
+ * This source code is protected under international copyright law.  All rights
+ * reserved and protected by the copyright holders.
+ * This file is confidential and only available to authorized individuals with the
+ * permission of the copyright holders.  If you encounter this file and do not have
+ * permission, please contact the copyright holders and delete this file.
+ */
 
 #pragma once
 
-#include "AzFramework/Physics/Collision/CollisionLayers.h"
-#include "AzFramework/Physics/Common/PhysicsEvents.h"
+#include "CsvSpawner/CsvSpawnerTypeIds.h"
 
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string.h>
-#include <AzFramework/Physics/PropertyTypes.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
+namespace CsvSpawner::CsvSpawnerUtils
 {
 
     //! Information about a locations to spawn an entity.
     //! This information is generated from CSV file and is used to spawn the entity.
-    //! @param m_name is the name of the spawnable entity configuration and should be identical to name in @class SpawnableAssetConfiguration.
+    //! @param m_name is the name of the spawnable entity configuration and should be identical to name in @class
+    //! SpawnableAssetConfiguration.
     class CsvSpawnableEntityInfo
     {
     public:
-        AZ_RTTI(CsvSpawnableEntityInfo, "{6acce47e-9cac-4a6e-8726-ea614fb2d30d}");
+        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
         static void Reflect(AZ::ReflectContext* context);
         CsvSpawnableEntityInfo() = default;
         virtual ~CsvSpawnableEntityInfo() = default;
@@ -44,12 +43,13 @@ namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
     //! Configuration for a spawnable asset
     //! This configuration is used to configure the spawnable asset before spawning it.
     //! The @param m_name is used to identify the spawnable asset configuration and should be identical to name given in CSV file.
-    //! The class allows user to specify multiple spawnable assets for a given name and randomization parameters for position, rotation and scale.
-    //! If more then one spawnable asset is specified for a given name, then one of the spawnable assets is randomly selected for spawning.
+    //! The class allows user to specify multiple spawnable assets for a given name and randomization parameters for position, rotation and
+    //! scale. If more then one spawnable asset is specified for a given name, then one of the spawnable assets is randomly selected for
+    //! spawning.
     class CsvSpawnableAssetConfiguration
     {
     public:
-        AZ_RTTI(CsvSpawnableAssetConfiguration, "{d04ea4de-b4dc-4e76-b742-c1d77203bc3e}");
+        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
         static void Reflect(AZ::ReflectContext* context);
         CsvSpawnableAssetConfiguration() = default;
         virtual ~CsvSpawnableAssetConfiguration() = default;
@@ -58,12 +58,12 @@ namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
         AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
         AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
         AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
-        float m_scaleStdDev { 0.1f }; //!< Standard deviation for scale
-        bool m_placeOnTerrain { false }; //!< Whether to raytrace to terrain and place the entity on the terrain
-        AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will be attached
+        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
+        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place the entity on the terrain
+		AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will be attached
 
     private:
-        bool bIsCollisionLayerEnabled() const;
+        bool IsCollisionLayerEnabled() const;
         AZ::Crc32 OnPlaceOnTerrainChanged();
     };
 
@@ -88,4 +88,4 @@ namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
         const AZStd::string& physicsSceneName = AZStd::string(),
         AZ::EntityId parentId = AZ::EntityId());
 
-}; // namespace RobotecEnvironmentSpawner::CsvSpawnerUtils
+}; // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -22,81 +22,83 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace CsvSpawner::CsvSpawnerUtils
-{
+namespace CsvSpawner::CsvSpawnerUtils {
 
-    //! Information about a locations to spawn an entity.
-    //! This information is generated from CSV file and is used to spawn the entity.
-    //! @param m_name is the name of the spawnable entity configuration and should
-    //! be identical to name in @class SpawnableAssetConfiguration.
-    class CsvSpawnableEntityInfo
-    {
-    public:
-        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
-        static void Reflect(AZ::ReflectContext* context);
-        CsvSpawnableEntityInfo() = default;
-        virtual ~CsvSpawnableEntityInfo() = default;
+//! Information about a locations to spawn an entity.
+//! This information is generated from CSV file and is used to spawn the entity.
+//! @param m_name is the name of the spawnable entity configuration and should
+//! be identical to name in @class SpawnableAssetConfiguration.
+class CsvSpawnableEntityInfo {
+public:
+  AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
+  static void Reflect(AZ::ReflectContext *context);
+  CsvSpawnableEntityInfo() = default;
+  virtual ~CsvSpawnableEntityInfo() = default;
 
-        unsigned int m_id; //!< Optional ID for the entity
-        AZ::Transform m_transform; //!< Transform of the entity, mandatory
-        AZStd::string m_name; //!< Name of the spawnable entity configuration, mandatory
-        uint64_t m_seed{ 0 }; //!< Optional seed value for randomization, in the context
-                              //!< of one spawnable entity configuration, optional
-    };
+  unsigned int m_id;         //!< Optional ID for the entity
+  AZ::Transform m_transform; //!< Transform of the entity, mandatory
+  AZStd::string
+      m_name;         //!< Name of the spawnable entity configuration, mandatory
+  uint64_t m_seed{0}; //!< Optional seed value for randomization, in the context
+                      //!< of one spawnable entity configuration, optional
+};
 
-    //! Configuration for a spawnable asset
-    //! This configuration is used to configure the spawnable asset before spawning
-    //! it. The @param m_name is used to identify the spawnable asset configuration
-    //! and should be identical to name given in CSV file. The class allows user to
-    //! specify multiple spawnable assets for a given name and randomization
-    //! parameters for position, rotation and scale. If more then one spawnable
-    //! asset is specified for a given name, then one of the spawnable assets is
-    //! randomly selected for spawning.
-    class CsvSpawnableAssetConfiguration
-    {
-    public:
-        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
-        static void Reflect(AZ::ReflectContext* context);
-        CsvSpawnableAssetConfiguration() = default;
-        virtual ~CsvSpawnableAssetConfiguration() = default;
+//! Configuration for a spawnable asset
+//! This configuration is used to configure the spawnable asset before spawning
+//! it. The @param m_name is used to identify the spawnable asset configuration
+//! and should be identical to name given in CSV file. The class allows user to
+//! specify multiple spawnable assets for a given name and randomization
+//! parameters for position, rotation and scale. If more then one spawnable
+//! asset is specified for a given name, then one of the spawnable assets is
+//! randomly selected for spawning.
+class CsvSpawnableAssetConfiguration {
+public:
+  AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
+  static void Reflect(AZ::ReflectContext *context);
+  CsvSpawnableAssetConfiguration() = default;
+  virtual ~CsvSpawnableAssetConfiguration() = default;
 
-        AZStd::string m_name; //!< Name of the spawnable field
-        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
-        AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
-        AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
-        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
-        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place
-                                        //!< the entity on the terrain
-        AzPhysics::CollisionGroups::Id m_selectedCollisionGroup; //!< To which collision group this target will
-                                                            //!< be attached
+  AZStd::string m_name; //!< Name of the spawnable field
+  AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>>
+      m_spawnables;                  //!< List of spawnable assets
+  AZ::Vector3 m_positionStdDev{0.f}; //!< Standard deviation for position
+  AZ::Vector3 m_rotationStdDev{0.f}; //!< Standard deviation for rotation
+  float m_scaleStdDev{0.1f};         //!< Standard deviation for scale
+  bool m_placeOnTerrain{false}; //!< Whether to raytrace to terrain and place
+                                //!< the entity on the terrain
+  AzPhysics::CollisionGroups::Id
+      m_selectedCollisionGroup; //!< To which collision group this target will
+                                //!< be attached
 
-    private:
-        [[nodiscard]] bool IsCollisionLayerEnabled() const;
-        static AZ::Crc32 OnPlaceOnTerrainChanged();
-    };
+private:
+  [[nodiscard]] bool IsCollisionLayerEnabled() const;
+  static AZ::Crc32 OnPlaceOnTerrainChanged();
+};
 
-    //! This function create map of spawnable asset configuration from vector of
-    //! spawnable asset configuration, where the key is the name of the spawnable
-    //! asset configuration
-    //! @param spawnableAssetConfigurations - vector of spawnable asset
-    //! configuration
-    //! @return map of spawnable asset configuration
-    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
-        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
+//! This function create map of spawnable asset configuration from vector of
+//! spawnable asset configuration, where the key is the name of the spawnable
+//! asset configuration
+//! @param spawnableAssetConfigurations - vector of spawnable asset
+//! configuration
+//! @return map of spawnable asset configuration
+AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+GetSpawnableAssetFromVector(
+    AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
 
-    //! Spawn entities from the vector of spawnable entity info
-    //! @param entitiesToSpawn - vector of spawnable entity info
-    //! @param spawnableAssetConfiguration - map of spawnable asset configuration
-    //! @param defaultSeed - default seed value
-    //! @param parentId - parent entity id to set for new entities
-    //! @param physicsSceneName - physics scene name
-    //! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
-    //! @return map of spawn created tickets
-    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
-        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
-        const AZ::u64 defaultSeed,
-        const AZStd::string& physicsSceneName = AZStd::string(),
-        AZ::EntityId parentId = AZ::EntityId());
+//! Spawn entities from the vector of spawnable entity info
+//! @param entitiesToSpawn - vector of spawnable entity info
+//! @param spawnableAssetConfiguration - map of spawnable asset configuration
+//! @param defaultSeed - default seed value
+//! @param parentId - parent entity id to set for new entities
+//! @param physicsSceneName - physics scene name
+//! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
+//! @return map of spawn created tickets
+AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
+    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+        &spawnableAssetConfiguration,
+    const AZ::u64 defaultSeed,
+    const AZStd::string &physicsSceneName = AZStd::string(),
+    AZ::EntityId parentId = AZ::EntityId());
 
 }; // namespace CsvSpawner::CsvSpawnerUtils

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.h
@@ -3,9 +3,10 @@
  *
  * This source code is protected under international copyright law.  All rights
  * reserved and protected by the copyright holders.
- * This file is confidential and only available to authorized individuals with the
- * permission of the copyright holders.  If you encounter this file and do not have
- * permission, please contact the copyright holders and delete this file.
+ * This file is confidential and only available to authorized individuals with
+ * the permission of the copyright holders.  If you encounter this file and do
+ * not have permission, please contact the copyright holders and delete this
+ * file.
  */
 
 #pragma once
@@ -20,73 +21,83 @@
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 
-namespace CsvSpawner::CsvSpawnerUtils
-{
+namespace CsvSpawner::CsvSpawnerUtils {
 
-    //! Information about a locations to spawn an entity.
-    //! This information is generated from CSV file and is used to spawn the entity.
-    //! @param m_name is the name of the spawnable entity configuration and should be identical to name in @class
-    //! SpawnableAssetConfiguration.
-    class CsvSpawnableEntityInfo
-    {
-    public:
-        AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
-        static void Reflect(AZ::ReflectContext* context);
-        CsvSpawnableEntityInfo() = default;
-        virtual ~CsvSpawnableEntityInfo() = default;
+//! Information about a locations to spawn an entity.
+//! This information is generated from CSV file and is used to spawn the entity.
+//! @param m_name is the name of the spawnable entity configuration and should
+//! be identical to name in @class SpawnableAssetConfiguration.
+class CsvSpawnableEntityInfo {
+public:
+  AZ_RTTI(CsvSpawnableEntityInfo, CsvSpawnableEntityInfoTypeId);
+  static void Reflect(AZ::ReflectContext *context);
+  CsvSpawnableEntityInfo() = default;
+  virtual ~CsvSpawnableEntityInfo() = default;
 
-        unsigned int m_id; //!< Optional ID for the entity
-        AZ::Transform m_transform; //!< Transform of the entity, mandatory
-        AZStd::string m_name; //!< Name of the spawnable entity configuration, mandatory
-        uint64_t m_seed{ 0 }; //!< Optional seed value for randomization, in the context of one spawnable entity configuration, optional
-    };
+  unsigned int m_id;         //!< Optional ID for the entity
+  AZ::Transform m_transform; //!< Transform of the entity, mandatory
+  AZStd::string
+      m_name;         //!< Name of the spawnable entity configuration, mandatory
+  uint64_t m_seed{0}; //!< Optional seed value for randomization, in the context
+                      //!< of one spawnable entity configuration, optional
+};
 
-    //! Configuration for a spawnable asset
-    //! This configuration is used to configure the spawnable asset before spawning it.
-    //! The @param m_name is used to identify the spawnable asset configuration and should be identical to name given in CSV file.
-    //! The class allows user to specify multiple spawnable assets for a given name and randomization parameters for position, rotation and
-    //! scale. If more then one spawnable asset is specified for a given name, then one of the spawnable assets is randomly selected for
-    //! spawning.
-    class CsvSpawnableAssetConfiguration
-    {
-    public:
-        AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
-        static void Reflect(AZ::ReflectContext* context);
-        CsvSpawnableAssetConfiguration() = default;
-        virtual ~CsvSpawnableAssetConfiguration() = default;
+//! Configuration for a spawnable asset
+//! This configuration is used to configure the spawnable asset before spawning
+//! it. The @param m_name is used to identify the spawnable asset configuration
+//! and should be identical to name given in CSV file. The class allows user to
+//! specify multiple spawnable assets for a given name and randomization
+//! parameters for position, rotation and scale. If more then one spawnable
+//! asset is specified for a given name, then one of the spawnable assets is
+//! randomly selected for spawning.
+class CsvSpawnableAssetConfiguration {
+public:
+  AZ_RTTI(CsvSpawnableAssetConfiguration, CsvSpawnableAssetConfigurationTypeId);
+  static void Reflect(AZ::ReflectContext *context);
+  CsvSpawnableAssetConfiguration() = default;
+  virtual ~CsvSpawnableAssetConfiguration() = default;
 
-        AZStd::string m_name; //!< Name of the spawnable field
-        AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>> m_spawnables; //!< List of spawnable assets
-        AZ::Vector3 m_positionStdDev{ 0.f }; //!< Standard deviation for position
-        AZ::Vector3 m_rotationStdDev{ 0.f }; //!< Standard deviation for rotation
-        float m_scaleStdDev{ 0.1f }; //!< Standard deviation for scale
-        bool m_placeOnTerrain{ false }; //!< Whether to raytrace to terrain and place the entity on the terrain
-		AzPhysics::CollisionLayer m_selectedCollisionLayer; //!< To which collision layer this target will be attached
+  AZStd::string m_name; //!< Name of the spawnable field
+  AZStd::vector<AZ::Data::Asset<AzFramework::Spawnable>>
+      m_spawnables;                  //!< List of spawnable assets
+  AZ::Vector3 m_positionStdDev{0.f}; //!< Standard deviation for position
+  AZ::Vector3 m_rotationStdDev{0.f}; //!< Standard deviation for rotation
+  float m_scaleStdDev{0.1f};         //!< Standard deviation for scale
+  bool m_placeOnTerrain{false}; //!< Whether to raytrace to terrain and place
+                                //!< the entity on the terrain
+  AzPhysics::CollisionLayer
+      m_selectedCollisionLayer; //!< To which collision layer this target will
+                                //!< be attached
 
-    private:
-        [[nodiscard]] bool IsCollisionLayerEnabled() const;
-        static AZ::Crc32 OnPlaceOnTerrainChanged();
-    };
+private:
+  [[nodiscard]] bool IsCollisionLayerEnabled() const;
+  static AZ::Crc32 OnPlaceOnTerrainChanged();
+};
 
-    //! This function create map of spawnable asset configuration from vector of spawnable asset configuration, where
-    //! the key is the name of the spawnable asset configuration
-    //! @param spawnableAssetConfigurations - vector of spawnable asset configuration
-    //! @return map of spawnable asset configuration
-    AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
-        AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
+//! This function create map of spawnable asset configuration from vector of
+//! spawnable asset configuration, where the key is the name of the spawnable
+//! asset configuration
+//! @param spawnableAssetConfigurations - vector of spawnable asset
+//! configuration
+//! @return map of spawnable asset configuration
+AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+GetSpawnableAssetFromVector(
+    AZStd::vector<CsvSpawnableAssetConfiguration> spawnableAssetConfigurations);
 
-    //! Spawn entities from the vector of spawnable entity info
-    //! @param entitiesToSpawn - vector of spawnable entity info
-    //! @param spawnableAssetConfiguration - map of spawnable asset configuration
-    //! @param defaultSeed - default seed value
-    //! @param parentId - parent entity id to set for new entities
-    //! @param physicsSceneName - physics scene name (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
-    //! @return map of spawn created tickets
-    AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
-        const AZStd::vector<CsvSpawnableEntityInfo>& entitiesToSpawn,
-        const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>& spawnableAssetConfiguration,
-        const AZ::u64 defaultSeed,
-        const AZStd::string& physicsSceneName = AZStd::string(),
-        AZ::EntityId parentId = AZ::EntityId());
+//! Spawn entities from the vector of spawnable entity info
+//! @param entitiesToSpawn - vector of spawnable entity info
+//! @param spawnableAssetConfiguration - map of spawnable asset configuration
+//! @param defaultSeed - default seed value
+//! @param parentId - parent entity id to set for new entities
+//! @param physicsSceneName - physics scene name
+//! (AzPhysics::DefaultPhysicsSceneName or AzPhysics::EditorPhysicsSceneName)
+//! @return map of spawn created tickets
+AZStd::unordered_map<int, AzFramework::EntitySpawnTicket> SpawnEntities(
+    const AZStd::vector<CsvSpawnableEntityInfo> &entitiesToSpawn,
+    const AZStd::unordered_map<AZStd::string, CsvSpawnableAssetConfiguration>
+        &spawnableAssetConfiguration,
+    const AZ::u64 defaultSeed,
+    const AZStd::string &physicsSceneName = AZStd::string(),
+    AZ::EntityId parentId = AZ::EntityId());
 
 }; // namespace CsvSpawner::CsvSpawnerUtils


### PR DESCRIPTION
I've added CollisionLayer to AssetConfig.
When Place On Terrain is Enabled - then a layer can be chosen to which object will be attached on spawn.
![Screenshot from 2024-10-10 13-05-47](https://github.com/user-attachments/assets/243e060a-598f-41f2-a4fe-f26355bf8a06)
![Screenshot from 2024-10-10 13-01-01](https://github.com/user-attachments/assets/b83730c4-ead6-4d27-8c1b-a02a4d9e96df)

