### PR TITLE
fixing typo in CsvSpawner

### DIFF
--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerCsvParser.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerCsvParser.cpp
@@ -90,7 +90,7 @@ namespace CsvSpawner::CsvSpawnerUtils
                     coordinate.m_altitude = row[index_alt.value()].get<double>();
                     AZ::Vector3 coordinateInLevel = AZ::Vector3(-1);
                     ROS2::GeoreferenceRequestsBus::BroadcastResult(
-                        coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
+                        coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWSG84ToLevel, coordinate);
                     AZ_Printf(
                         "TreeSpawnerEditorComponent",
                         "Converted WGS84 coordinate to level coordinate: %f, %f, %f WGS84: %f, %f, %f\n",


### PR DESCRIPTION
I've got an error:
```cpp
error: no member named 'ConvertFromWGS84ToLevel' in 'ROS2::GeoreferenceRequests'; did you mean '::ROS2::GeoreferenceRequests::ConvertFromWSG84ToLevel'?
                        coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                            ::ROS2::GeoreferenceRequests::ConvertFromWSG84ToLevel
```
Issue is with the naming used in 
```cpp
ConvertFromWGS84ToLevel
```
Where should be, it should be (typo `WGS` -> `WSG`):
```cpp
ConvertFromWSG84ToLevel
```
