### PR TITLE
Spline subscriber component

### DIFF
--- a/Gems/RobotecSplineTools/Code/CMakeLists.txt
+++ b/Gems/RobotecSplineTools/Code/CMakeLists.txt
@@ -53,6 +53,7 @@ ly_add_target(
             AZ::AzFramework
             Gem::Atom_RPI.Public
             Gem::AtomLyIntegration_CommonFeatures.Static
+            Gem::ROS2.Static
 )
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface

--- a/Gems/RobotecSplineTools/Code/CMakeLists.txt
+++ b/Gems/RobotecSplineTools/Code/CMakeLists.txt
@@ -50,6 +50,9 @@ ly_add_target(
         PUBLIC
             AZ::AzCore
             AZ::AzFramework
+            AZ::AzFramework
+            Gem::Atom_RPI.Public
+            Gem::AtomLyIntegration_CommonFeatures.Static
 )
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface

--- a/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
+++ b/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
@@ -18,4 +18,9 @@ namespace SplineTools
     inline constexpr const char* SplineToolsRequestsTypeId = "{8D969183-259F-4790-9C5C-4F25BD2746FD}";
 
     inline constexpr const char* VisualizeSplineComponentTypeId = "{5D69075B-BB8A-4336-829A-B3A84FB6DCE8}";
+
+    inline constexpr const char* SplineSubscriberComponentTypeId = "{89B8A92A-8F17-4C30-AE0D-6B088C133283}";
+    inline constexpr const char* SplineSubscriberConfigTypeId = "{44317FD2-51A1-41CA-BA44-F8BCAE9757CE}";
+
+
 } // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
+++ b/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
@@ -22,5 +22,4 @@ namespace SplineTools
     inline constexpr const char* SplineSubscriberComponentTypeId = "{89B8A92A-8F17-4C30-AE0D-6B088C133283}";
     inline constexpr const char* SplineSubscriberConfigTypeId = "{44317FD2-51A1-41CA-BA44-F8BCAE9757CE}";
 
-
 } // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
+++ b/Gems/RobotecSplineTools/Code/Include/SplineTools/SplineToolsTypeIds.h
@@ -16,4 +16,6 @@ namespace SplineTools
 
     // Interface TypeIds
     inline constexpr const char* SplineToolsRequestsTypeId = "{8D969183-259F-4790-9C5C-4F25BD2746FD}";
+
+    inline constexpr const char* VisualizeSplineComponentTypeId = "{5D69075B-BB8A-4336-829A-B3A84FB6DCE8}";
 } // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.cpp
@@ -1,7 +1,9 @@
 #include "SplineSubscriber.h"
 
+#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <LmbrCentral/Shape/SplineComponentBus.h>
 #include <ROS2/Georeference/GeoreferenceBus.h>
 
 namespace SplineTools
@@ -54,7 +56,6 @@ namespace SplineTools
 
     void SplineSubscriber::OnSplineReceived(const nav_msgs::msg::Path& msg)
     {
-        AZ_Printf("SplineSubscriber", "Received spline message");
         AZ::SplinePtr splinePtr;
         LmbrCentral::SplineComponentRequestBus::EventResult(
             splinePtr, GetEntityId(), &LmbrCentral::SplineComponentRequestBus::Events::GetSpline);
@@ -63,19 +64,21 @@ namespace SplineTools
         AZ::Transform worldTm = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldTm, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
         worldTm.Invert();
+        AZStd::string frame{ msg.header.frame_id.c_str(), msg.header.frame_id.size() };
+        AZStd::to_upper(frame.begin(), frame.end());
+        AZ_Printf("SplineSubscriber", "Frame: %s", frame.data());
         AZStd::vector<AZ::Vector3> points(msg.poses.size());
         for (size_t i = 0; i < msg.poses.size(); ++i)
         {
             const auto& poseStamped = msg.poses[i];
             const auto& pose = poseStamped.pose;
             const AZ::Vector3 posePoint = AZ::Vector3(pose.position.x, pose.position.y, pose.position.z);
-            AZStd::string frame{ poseStamped.header.frame_id.c_str(), poseStamped.header.frame_id.size() };
-            AZStd::to_upper(frame);
+
             if (frame.empty())
             {
                 points[i] = worldTm.TransformPoint(posePoint);
             }
-            else if (frame.compare("WGS84") && m_config.m_allowWGS84)
+            else if (frame == "WGS84" && m_config.m_allowWGS84)
             {
                 ROS2::WGS::WGS84Coordinate currentPositionWGS84;
                 currentPositionWGS84.m_latitude = pose.position.x;
@@ -89,12 +92,12 @@ namespace SplineTools
             else
             {
                 AZ_Error("SplineSubscriber", false, "Not implemented with frame %s", frame.data());
-                points[i] = worldTm.TransformPoint(posePoint);
             }
         }
         LmbrCentral::SplineComponentRequestBus::Event(GetEntityId(), &LmbrCentral::SplineComponentRequestBus::Events::ClearVertices);
         LmbrCentral::SplineComponentRequestBus::Event(GetEntityId(), &LmbrCentral::SplineComponentRequestBus::Events::SetVertices, points);
     }
+
     void SplineSubscriber::Deactivate()
     {
         m_subscription.reset();

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.cpp
@@ -1,0 +1,59 @@
+#include "SplineSubscriber.h"
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace SplineTools
+{
+
+    void SplineSubscriber::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("TransformService"));
+        required.push_back(AZ_CRC_CE("SplineService"));
+    }
+
+    void SplineSubscriber::Reflect(AZ::ReflectContext* context)
+    {
+        SplineSubscriberConfiguration::Reflect(context);
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SplineSubscriber>()->Version(0)->Field("m_config", &SplineSubscriber::m_config);
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<SplineSubscriber>("SplineSubscriber", "Configuration for the SplineSubscriber component")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "SplineSubscriber")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "RobotecTools")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SplineSubscriber::m_config,
+                        "Configuration",
+                        "Configuration for the SplineSubscriber component");
+            }
+        }
+    }
+
+    void SplineSubscriber::Activate()
+    {
+        auto node = ROS2::ROS2Interface::Get()->GetNode();
+        AZ_Assert(node, "ROS 2 Node is not available");
+        m_subscription = node->create_subscription<geometry_msgs::msg::PoseStamped>(
+            m_config.m_topic.m_topic.data(),
+            m_config.m_topic.GetQoS(),
+            [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+            {
+                OnSplineReceived(*msg);
+            });
+    }
+
+    void SplineSubscriber::OnSplineReceived(const geometry_msgs::msg::PoseStamped& msg)
+    {
+        AZ_Printf("SplineSubscriber", "Received spline message");
+    }
+    void SplineSubscriber::Deactivate()
+    {
+        m_subscription.reset();
+    }
+
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <SplineTools/SplineToolsTypeIds.h>
+#include "SplineSubscriberConfig.h"
+#include <ROS2/ROS2Bus.h>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+namespace SplineTools
+{
+    class SplineSubscriber : public AZ::Component
+    {
+    public:
+        AZ_COMPONENT(SplineSubscriber, SplineSubscriberComponentTypeId, AZ::Component);
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        // AZ::Component overrides ...
+        void Activate() override;
+        void Deactivate() override;
+    private:
+        void OnSplineReceived(const geometry_msgs::msg::PoseStamped& msg);
+        SplineSubscriberConfiguration m_config;
+        rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr m_subscription;
+    };
+
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
@@ -11,7 +11,7 @@ namespace SplineTools
     class SplineSubscriber : public AZ::Component
     {
     public:
-        AZ_COMPONENT(SplineSubscriber, SplineSubscriberComponentTypeId, AZ::Component);
+        AZ_COMPONENT(SplineSubscriber, SplineSubscriberComponentTypeId);
 
         static void Reflect(AZ::ReflectContext* context);
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriber.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <AzCore/Component/Component.h>
-#include <SplineTools/SplineToolsTypeIds.h>
 #include "SplineSubscriberConfig.h"
+#include <AzCore/Component/Component.h>
 #include <ROS2/ROS2Bus.h>
-#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <SplineTools/SplineToolsTypeIds.h>
+#include <nav_msgs/msg/path.hpp>
 
 namespace SplineTools
 {
@@ -18,10 +18,11 @@ namespace SplineTools
         // AZ::Component overrides ...
         void Activate() override;
         void Deactivate() override;
+
     private:
-        void OnSplineReceived(const geometry_msgs::msg::PoseStamped& msg);
+        void OnSplineReceived(const nav_msgs::msg::Path& msg);
         SplineSubscriberConfiguration m_config;
-        rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr m_subscription;
+        rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr m_subscription;
     };
 
 } // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.cpp
@@ -1,0 +1,29 @@
+#include "SplineSubscriberConfig.h"
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+namespace SplineTools
+{
+    SplineSubscriberConfiguration::SplineSubscriberConfiguration()
+    {
+        m_topic.m_type = "geometry_msgs/msg/PoseStamped";
+        m_topic.m_topic = "spline";
+    }
+
+    void SplineSubscriberConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<SplineSubscriberConfiguration>()
+                ->Version(0)
+                ->Field("m_topicName", &SplineSubscriberConfiguration::m_topic);
+            if (auto editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<SplineSubscriberConfiguration>("SplineSubscriberConfiguration", "Configuration for the SplineSubscriber component")
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "SplineSubscriber Configuration")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SplineSubscriberConfiguration::m_topic, "Topic", "Topic");
+            }
+        }
+    }
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.cpp
@@ -1,7 +1,7 @@
 #include "SplineSubscriberConfig.h"
 
-#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace SplineTools
 {
@@ -17,12 +17,22 @@ namespace SplineTools
         {
             serializeContext->Class<SplineSubscriberConfiguration>()
                 ->Version(0)
-                ->Field("m_topicName", &SplineSubscriberConfiguration::m_topic);
+                ->Field("m_topicName", &SplineSubscriberConfiguration::m_topic)
+                ->Field("m_allowWGS84", &SplineSubscriberConfiguration::m_allowWGS84)
+                ->Field("m_resetOnActivation", &SplineSubscriberConfiguration::m_resetOnActivation);
             if (auto editContext = serializeContext->GetEditContext())
             {
-                editContext->Class<SplineSubscriberConfiguration>("SplineSubscriberConfiguration", "Configuration for the SplineSubscriber component")
+                editContext
+                    ->Class<SplineSubscriberConfiguration>(
+                        "SplineSubscriberConfiguration", "Configuration for the SplineSubscriber component")
                     ->ClassElement(AZ::Edit::ClassElements::Group, "SplineSubscriber Configuration")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SplineSubscriberConfiguration::m_topic, "Topic", "Topic");
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SplineSubscriberConfiguration::m_topic, "Topic", "Topic")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &SplineSubscriberConfiguration::m_allowWGS84, "Allow WGS84", "Allow WGS84")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &SplineSubscriberConfiguration::m_resetOnActivation,
+                        "Reset On Activation",
+                        "Reset On Activation");
             }
         }
     }

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.h
@@ -15,6 +15,7 @@ namespace SplineTools
         AZ_TYPE_INFO(SplineSubscriberConfiguration, SplineSubscriberConfigTypeId);
         static void Reflect(AZ::ReflectContext* context);
         ROS2::TopicConfiguration m_topic{ rclcpp::ServicesQoS() };
-        bool m_allowWGS84{ true };
+        bool m_allowWGS84{ true }; //! Allow WGS84 coordinates.
+        bool m_resetOnActivation{ true }; //! Reset entity's spline on activation.
     };
 } // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/SplineSubscriberConfig.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <ROS2/Communication/TopicConfiguration.h>
+#include <SplineTools/SplineToolsTypeIds.h>
+
+namespace SplineTools
+{
+    //! A structure capturing configuration of a IMU sensor.
+    struct SplineSubscriberConfiguration
+    {
+        SplineSubscriberConfiguration();
+
+        AZ_TYPE_INFO(SplineSubscriberConfiguration, SplineSubscriberConfigTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+        ROS2::TopicConfiguration m_topic{ rclcpp::ServicesQoS() };
+        bool m_allowWGS84{ true };
+    };
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.cpp
@@ -37,6 +37,7 @@ namespace SplineTools
             }
         }
     }
+
     void VisualizeSplineComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ_CRC_CE("TransformService"));

--- a/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.cpp
@@ -1,0 +1,103 @@
+#include "VisualizeSplineComponent.h"
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+#include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
+#include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <AzCore/Component/TransformBus.h>
+#include <LmbrCentral/Shape/SplineComponentBus.h>
+namespace SplineTools
+{
+    void VisualizeSplineComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<VisualizeSplineComponent, AZ::Component>()
+                ->Version(0)
+                ->Field("resolution", &VisualizeSplineComponent::m_resolution)
+                ->Field("nodeRadius", &VisualizeSplineComponent::m_nodeRadius);
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<VisualizeSplineComponent>("VisualizeSplineComponent", "SplineToolsEditorComponent")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "VisualizeSplineComponent")
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::Category, "RobotecTools")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &VisualizeSplineComponent::m_resolution,
+                        "Resolution",
+                        "Resolution of the spline visualization")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &VisualizeSplineComponent::m_nodeRadius,
+                        "Node Radius",
+                        "Radius of the nodes in the spline visualization");
+            }
+        }
+    }
+    void VisualizeSplineComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+    {
+        required.push_back(AZ_CRC_CE("TransformService"));
+        required.push_back(AZ_CRC_CE("SplineService"));
+    }
+
+    void VisualizeSplineComponent::Activate()
+    {
+        auto* entityScene = AZ::RPI::Scene::GetSceneForEntityId(m_entity->GetId());
+        m_drawQueue = AZ::RPI::AuxGeomFeatureProcessorInterface::GetDrawQueueForScene(entityScene);
+        AZ_Assert(m_drawQueue, "AuxGeomFeatureProcessorInterface not available for scene");
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void VisualizeSplineComponent::Deactivate()
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+        m_drawQueue = nullptr;
+    }
+
+    void VisualizeSplineComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        if (m_drawQueue)
+        {
+            AZ::Transform worldTm = AZ::Transform::CreateIdentity();
+            AZ::TransformBus::EventResult(worldTm, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+
+            AZ::SplinePtr splinePtr;
+            LmbrCentral::SplineComponentRequestBus::EventResult(
+                splinePtr, GetEntityId(), &LmbrCentral::SplineComponentRequestBus::Events::GetSpline);
+
+            AZ_Assert(splinePtr, "SplineComponentRequestBus::Events::GetSpline failed");
+
+            for (size_t i = 0; i < splinePtr->GetVertexCount(); i++)
+            {
+                AZ::Vector3 point = splinePtr->GetVertex(i);
+                point = worldTm.TransformPoint(point);
+
+                m_drawQueue->DrawSphere(point, m_nodeRadius, AZ::Colors::Red);
+            }
+            std::vector<AZ::Vector3> splineVertices;
+            splineVertices.reserve(m_resolution);
+            for (unsigned int i = 0; i < m_resolution; i++)
+            {
+                float t = static_cast<float>(i) / static_cast<float>(m_resolution);
+
+                auto address = splinePtr->GetAddressByFraction(t);
+
+                AZ::Vector3 point = splinePtr->GetPosition(address);
+                splineVertices.push_back(worldTm.TransformPoint(point));
+            }
+
+            AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments drawArgs;
+            drawArgs.m_verts = splineVertices.data();
+            drawArgs.m_vertCount = splineVertices.size();
+            drawArgs.m_colors = &AZ::Colors::White;
+            drawArgs.m_colorCount = 1u;
+            drawArgs.m_opacityType = AZ::RPI::AuxGeomDraw::OpacityType::Opaque;
+            drawArgs.m_size = 1u;
+            m_drawQueue->DrawLines(drawArgs);
+        }
+    }
+
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.h
+++ b/Gems/RobotecSplineTools/Code/Source/Clients/VisualizeSplineComponent.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+#include <SplineTools/SplineToolsTypeIds.h>
+namespace SplineTools
+{
+    class VisualizeSplineComponent
+        : public AZ::Component
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(VisualizeSplineComponent, VisualizeSplineComponentTypeId, AZ::Component);
+
+        static void Reflect(AZ::ReflectContext* context);
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        // AZ::Component overrides ...
+        void Activate() override;
+        void Deactivate() override;
+
+        // AZ::TickBus::Handler overrides ...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+    private:
+        AZ::RPI::AuxGeomDrawPtr m_drawQueue;
+        unsigned int m_resolution = 100;
+        float m_nodeRadius = 0.1f;
+    };
+} // namespace SplineTools

--- a/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
@@ -5,6 +5,7 @@
 #include <SplineTools/SplineToolsTypeIds.h>
 
 #include <Clients/SplineToolsSystemComponent.h>
+#include <Clients/VisualizeSplineComponent.h>
 
 namespace SplineTools
 {
@@ -22,6 +23,7 @@ namespace SplineTools
             m_descriptors.end(),
             {
                 SplineToolsSystemComponent::CreateDescriptor(),
+                VisualizeSplineComponent::CreateDescriptor(),
             });
     }
 

--- a/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
@@ -4,9 +4,9 @@
 
 #include <SplineTools/SplineToolsTypeIds.h>
 
+#include <Clients/SplineSubscriber.h>
 #include <Clients/SplineToolsSystemComponent.h>
 #include <Clients/VisualizeSplineComponent.h>
-#include <Clients/SplineSubscriber.h>
 
 namespace SplineTools
 {
@@ -22,11 +22,9 @@ namespace SplineTools
         // This happens through the [MyComponent]::Reflect() function.
         m_descriptors.insert(
             m_descriptors.end(),
-            {
-                SplineToolsSystemComponent::CreateDescriptor(),
-                VisualizeSplineComponent::CreateDescriptor(),
-                SplineSubscriber::CreateDescriptor()
-            });
+            { SplineToolsSystemComponent::CreateDescriptor(),
+              VisualizeSplineComponent::CreateDescriptor(),
+              SplineSubscriber::CreateDescriptor() });
     }
 
     AZ::ComponentTypeList SplineToolsModuleInterface::GetRequiredSystemComponents() const

--- a/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
+++ b/Gems/RobotecSplineTools/Code/Source/SplineToolsModuleInterface.cpp
@@ -6,6 +6,7 @@
 
 #include <Clients/SplineToolsSystemComponent.h>
 #include <Clients/VisualizeSplineComponent.h>
+#include <Clients/SplineSubscriber.h>
 
 namespace SplineTools
 {
@@ -24,6 +25,7 @@ namespace SplineTools
             {
                 SplineToolsSystemComponent::CreateDescriptor(),
                 VisualizeSplineComponent::CreateDescriptor(),
+                SplineSubscriber::CreateDescriptor()
             });
     }
 

--- a/Gems/RobotecSplineTools/Code/splinetools_private_files.cmake
+++ b/Gems/RobotecSplineTools/Code/splinetools_private_files.cmake
@@ -6,4 +6,8 @@ set(FILES
     Source/Clients/SplineToolsSystemComponent.h
     Source/Clients/VisualizeSplineComponent.cpp
     Source/Clients/VisualizeSplineComponent.h
+    Source/Clients/SplineSubscriber.h
+    Source/Clients/SplineSubscriber.cpp
+    Source/Clients/SplineSubscriberConfig.h
+    Source/Clients/SplineSubscriberConfig.cpp
 )

--- a/Gems/RobotecSplineTools/Code/splinetools_private_files.cmake
+++ b/Gems/RobotecSplineTools/Code/splinetools_private_files.cmake
@@ -4,4 +4,6 @@ set(FILES
     Source/SplineToolsModuleInterface.h
     Source/Clients/SplineToolsSystemComponent.cpp
     Source/Clients/SplineToolsSystemComponent.h
+    Source/Clients/VisualizeSplineComponent.cpp
+    Source/Clients/VisualizeSplineComponent.h
 )


### PR DESCRIPTION
Change introduces spline SplineSubscriber component :
![image](https://github.com/user-attachments/assets/e14178c9-891b-420d-9ca0-4d8b62087d89)

This component allows to modify spline with message of type nav_msgs::msg::Path.
There are two frames supported:
- `wgs84` that will interpret path as geographical coordinates
- `` (empty) that will be interpreted

 as level coordinates.
Other frames are not supported by this component.

# How it was tested?
I've used a level available here:
[geolevelTest.zip](https://github.com/user-attachments/files/17801405/geolevelTest.zip)

I've designed path in Google Earth and exported KML:
![image](https://github.com/user-attachments/assets/98869bdc-5673-465e-bd9f-f9fe00bb8d1f)
The KML:
[TestPath.zip](https://github.com/user-attachments/files/17801417/TestPath.zip)

Next the path was converted from KML to ROS 2 message with code generated with Generative Model:
https://chatgpt.com/share/673b104d-8edc-8008-9b66-badde0fcf65b

Finally, I've started O3DE and started generated python code next resulting with:
![image](https://github.com/user-attachments/assets/c701f063-3020-4ad1-a938-9160a7f716c0)

**NOTE**
The sample level used ortophoto map from [ISOK](https://isok.gov.pl/index.html). That is different from that we can in Google Earth.