### PR TITLE
[2409] Watchdog rule for required components verification.

### DIFF
--- a/Gems/RobotecWatchdogTools/Code/Include/WatchdogTools/WatchdogToolsBus.h
+++ b/Gems/RobotecWatchdogTools/Code/Include/WatchdogTools/WatchdogToolsBus.h
@@ -12,6 +12,7 @@
 
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Interface/Interface.h>
+#include <AzCore/std/string/string.h>
 
 namespace WatchdogTools
 {
@@ -29,7 +30,8 @@ namespace WatchdogTools
         /*
          * Enumerate the dynamic modules used by a project and prevent from start if any required module fails to load
          */
-        virtual void CheckRequiredModules() = 0;
+        virtual AZ::Outcome<bool, AZStd::string> CheckRequiredModules() = 0;
+        virtual AZ::Outcome<bool, AZStd::string> VerifyComponentsLoaded() = 0;
     };
 
     class WatchdogToolsBusTraits : public AZ::EBusTraits

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.cpp
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.cpp
@@ -50,7 +50,6 @@ namespace WatchdogTools
 
         constexpr WatchdogSettingsRootKeyType WatchdogSettingsRootKey;
 
-        constexpr auto WatchdogRequiredModulesRegistryKey = WatchdogSettingsRootKey("RequiredModules");
     } // namespace
 
     void WatchdogSettings::Reflect(AZ::ReflectContext* context)
@@ -73,7 +72,7 @@ namespace WatchdogTools
         }
     }
 
-    void WatchdogSettings::LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry)
+    void WatchdogSettings::LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry, AZStd::string_view modulesKey)
     {
         if (settingsRegistry == nullptr)
         {
@@ -97,7 +96,7 @@ namespace WatchdogTools
             return AZ::SettingsRegistryInterface::VisitResponse::Continue;
         };
         [[maybe_unused]] bool result =
-            AZ::SettingsRegistryVisitorUtils::VisitArray(*settingsRegistry, CollectRequiredModules, WatchdogRequiredModulesRegistryKey);
+            AZ::SettingsRegistryVisitorUtils::VisitArray(*settingsRegistry, CollectRequiredModules, WatchdogSettingsRootKey(modulesKey));
         AZ_Warning("WatchdogSettings", result, "Required modules not read. Use defaults");
     }
 } // namespace WatchdogTools

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.h
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.h
@@ -28,7 +28,7 @@ namespace WatchdogTools
         //! the ability to create a default set of values by using the default constructor.
         //! If we read these in the constructor, serialization would see all of the current values
         //! as default values and would try to prune them from the output by default.
-        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get());
+        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get(),  AZStd::string_view modulesKey = "");
 
         AZStd::vector<AZStd::string> m_requiredModules;
     };

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.h
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSettings.h
@@ -28,7 +28,8 @@ namespace WatchdogTools
         //! the ability to create a default set of values by using the default constructor.
         //! If we read these in the constructor, serialization would see all of the current values
         //! as default values and would try to prune them from the output by default.
-        void LoadSettings(AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get(),  AZStd::string_view modulesKey = "");
+        void LoadSettings(
+            AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get(), AZStd::string_view modulesKey = "");
 
         AZStd::vector<AZStd::string> m_requiredModules;
     };

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
@@ -10,18 +10,18 @@
 
 #include "AzCore/Module/DynamicModuleHandle.h"
 #include "AzCore/Module/ModuleManagerBus.h"
-#include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Serialization/SerializeContext.h>
-#include <Clients/WatchdogToolsSettings.h>
-#include <WatchdogTools/WatchdogToolsTypeIds.h>
-#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Module/ModuleManagerBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
 #include <AzCore/std/containers/set.h>
-#include <AzCore/Component/Entity.h>
+#include <Clients/WatchdogToolsSettings.h>
+#include <WatchdogTools/WatchdogToolsTypeIds.h>
 
 namespace WatchdogTools
 {
@@ -71,7 +71,7 @@ namespace WatchdogTools
         {
             AZ_Warning("Watchdog", false, allModulesLoaded.GetError().c_str());
         }
-        else if(!allModulesLoaded.GetValue())
+        else if (!allModulesLoaded.GetValue())
         {
             std::terminate();
         }
@@ -111,11 +111,10 @@ namespace WatchdogTools
                     requiredDynamicModules.erase(moduleName);
 
                     return true;
-                }
-            );
+                });
 
             bool allRequiredModulesLoaded = requiredDynamicModules.empty();
-            
+
             if (!allRequiredModulesLoaded)
             {
                 for (auto nonLoadedModule : requiredDynamicModules)
@@ -124,7 +123,7 @@ namespace WatchdogTools
                 }
                 AZ_Fatal("Watchdog", "Some required modules were not loaded. Check the console output for errors");
             }
-            
+
             return AZ::Success(allRequiredModulesLoaded);
         }
         else
@@ -176,7 +175,7 @@ namespace WatchdogTools
         {
             return AZ::Failure("SettingsRegistry for WatchdogTools inaccessible");
         }
-        
+
         return AZ::Success(allComponentsLoaded);
     }
 

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.cpp
@@ -14,6 +14,14 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <Clients/WatchdogToolsSettings.h>
 #include <WatchdogTools/WatchdogToolsTypeIds.h>
+#include <AzCore/Settings/SettingsRegistryVisitorUtils.h>
+#include <AzCore/Component/ComponentApplication.h>
+#include <AzCore/Component/ComponentApplicationBus.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Module/ModuleManagerBus.h>
+#include <AzCore/Settings/SettingsRegistry.h>
+#include <AzCore/std/containers/set.h>
+#include <AzCore/Component/Entity.h>
 
 namespace WatchdogTools
 {
@@ -58,7 +66,15 @@ namespace WatchdogTools
     {
         WatchdogToolsRequestBus::Handler::BusConnect();
 #if !defined(AZ_MONOLITHIC_BUILD)
-        CheckRequiredModules();
+        auto allModulesLoaded = CheckRequiredModules();
+        if (!allModulesLoaded.IsSuccess())
+        {
+            AZ_Warning("Watchdog", false, allModulesLoaded.GetError().c_str());
+        }
+        else if(!allModulesLoaded.GetValue())
+        {
+            std::terminate();
+        }
 #endif
     }
 
@@ -67,46 +83,101 @@ namespace WatchdogTools
         WatchdogToolsRequestBus::Handler::BusDisconnect();
     }
 
-    void WatchdogToolsSystemComponent::CheckRequiredModules()
+    AZ::Outcome<bool, AZStd::string> WatchdogToolsSystemComponent::CheckRequiredModules()
     {
-        AZ::SettingsRegistryInterface* settingsRegistry = AZ::SettingsRegistry::Get();
-        AZ_Assert(settingsRegistry, "Settings Registry Interface not available");
-        WatchdogSettings watchdogSettings;
-        watchdogSettings.LoadSettings(settingsRegistry);
-        AZStd::set<AZStd::string> requiredDynamicModules = GatherDynamicModules(watchdogSettings.m_requiredModules);
-        AZ::ModuleManagerRequestBus::Broadcast(
-            &AZ::ModuleManagerRequestBus::Events::EnumerateModules,
-            [&requiredDynamicModules](const AZ::ModuleData& moduleData)
-            {
-                // // We can only enumerate shared libs, static libs are invisible to us
-                auto handle = moduleData.GetDynamicModuleHandle();
-                if (!handle)
+        if (auto settingsRegistry = AZ::Interface<AZ::SettingsRegistryInterface>::Get(); settingsRegistry != nullptr)
+        {
+            WatchdogSettings watchdogSettings;
+            watchdogSettings.LoadSettings(settingsRegistry, "RequiredModules");
+            AZStd::set<AZStd::string> requiredDynamicModules = GatherDynamicModules(watchdogSettings.m_requiredModules);
+            AZ::ModuleManagerRequestBus::Broadcast(
+                &AZ::ModuleManagerRequestBus::Events::EnumerateModules,
+                [&requiredDynamicModules](const AZ::ModuleData& moduleData)
                 {
+                    // // We can only enumerate shared libs, static libs are invisible to us
+                    auto handle = moduleData.GetDynamicModuleHandle();
+                    if (!handle)
+                    {
+                        return true;
+                    }
+                    bool isLoaded = moduleData.GetDynamicModuleHandle()->IsLoaded();
+                    if (!isLoaded)
+                    {
+                        AZ_Warning("Watchdog", false, "Module %s is NOT loaded ", moduleData.GetDebugName());
+                        return false;
+                    }
+                    AZStd::string_view moduleName = moduleData.GetDebugName();
+
+                    requiredDynamicModules.erase(moduleName);
+
                     return true;
                 }
-                bool isLoaded = moduleData.GetDynamicModuleHandle()->IsLoaded();
-                if (!isLoaded)
-                {
-                    AZ_Warning("Watchdog", false, "Module %s is NOT loaded ", moduleData.GetDebugName());
-                    return false;
-                }
-                AZStd::string_view moduleName = moduleData.GetDebugName();
+            );
 
-                requiredDynamicModules.erase(moduleName);
-
-                return true;
-            });
-
-        if (!requiredDynamicModules.empty())
-        {
-            for (auto nonLoadedModule : requiredDynamicModules)
+            bool allRequiredModulesLoaded = requiredDynamicModules.empty();
+            
+            if (!allRequiredModulesLoaded)
             {
-                AZ_Printf("Watchdog", "Failed to load module: " AZ_STRING_FORMAT "\n", AZ_STRING_ARG(nonLoadedModule));
+                for (auto nonLoadedModule : requiredDynamicModules)
+                {
+                    AZ_Printf("Watchdog", "Failed to load module: " AZ_STRING_FORMAT "\n", AZ_STRING_ARG(nonLoadedModule));
+                }
+                AZ_Fatal("Watchdog", "Some required modules were not loaded. Check the console output for errors");
             }
-            AZ_Fatal("Watchdog", "Some required modules were not loaded. Check the console output for errors");
-
-            std::terminate();
+            
+            return AZ::Success(allRequiredModulesLoaded);
         }
+        else
+        {
+            return AZ::Failure("SettingsRegistry for WatchdogTools inaccessible");
+        }
+    }
+
+    AZ::Outcome<bool, AZStd::string> WatchdogToolsSystemComponent::VerifyComponentsLoaded()
+    {
+        bool allComponentsLoaded = true;
+        if (auto settingsRegistry = AZ::Interface<AZ::SettingsRegistryInterface>::Get(); settingsRegistry != nullptr)
+        {
+            WatchdogSettings watchdogSettings;
+            watchdogSettings.LoadSettings(settingsRegistry, "RequiredComponents");
+            auto requiredComponents = watchdogSettings.m_requiredModules;
+            AZStd::set<AZStd::string> loadedComponentsNames;
+            auto enumerateComponentsEntities = [&loadedComponentsNames](AZ::Entity* entity)
+            {
+                for (auto component : entity->GetComponents())
+                {
+                    loadedComponentsNames.insert(component->RTTI_GetTypeName());
+                }
+            };
+            AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationRequests::EnumerateEntities, enumerateComponentsEntities);
+
+            auto enumerateComponentsModules = [&loadedComponentsNames](const AZ::ModuleData& moduleData) -> bool
+            {
+                const AZ::Entity* entity = moduleData.GetEntity();
+
+                for (auto component : entity->GetComponents())
+                {
+                    loadedComponentsNames.insert(component->RTTI_GetTypeName());
+                }
+                return true;
+            };
+            AZ::ModuleManagerRequestBus::Broadcast(&AZ::ModuleManagerRequests::EnumerateModules, enumerateComponentsModules);
+
+            for (auto& requiredComponent : requiredComponents)
+            {
+                if (loadedComponentsNames.find(requiredComponent) == loadedComponentsNames.end())
+                {
+                    allComponentsLoaded = false;
+                    AZ_Warning("Watchdog", false, "Missing required component " AZ_STRING_FORMAT "\n", AZ_STRING_ARG(requiredComponent));
+                }
+            }
+        }
+        else
+        {
+            return AZ::Failure("SettingsRegistry for WatchdogTools inaccessible");
+        }
+        
+        return AZ::Success(allComponentsLoaded);
     }
 
     AZStd::set<AZStd::string> WatchdogToolsSystemComponent::GatherDynamicModules(const AZStd::vector<AZStd::string>& modules)

--- a/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.h
+++ b/Gems/RobotecWatchdogTools/Code/Source/Clients/WatchdogToolsSystemComponent.h
@@ -31,7 +31,8 @@ namespace WatchdogTools
 
         ~WatchdogToolsSystemComponent();
 
-        void CheckRequiredModules() override;
+        AZ::Outcome<bool, AZStd::string> CheckRequiredModules() override;
+        AZ::Outcome<bool, AZStd::string> VerifyComponentsLoaded() override;
 
     protected:
         // AZ::Component overrides ...

--- a/Gems/RobotecWatchdogTools/readme.md
+++ b/Gems/RobotecWatchdogTools/readme.md
@@ -13,7 +13,9 @@ The gem has minimal requirements, and it's on purpose: we want to minimize the s
 - Create a setreg file with Watchdog rules in your project's registry.
 - Good rule of thumb is to maintain two files: one for the Editor and a second for GameLauncher.
 
-## Example:
+## Examples:
+
+# Verify dynamic modules in Editor runtime
 
 Below is an example how to prevent Editor from starting if `ROS2.Editor` or `my_example_gem.Editor` is not loaded. 
 
@@ -39,13 +41,44 @@ with the following content:
 }
 ```
 
+# Verify if certain components are loaded
+
+Apart from dynamic module check on Editor start, this Gem provides API for checks wheather all components listed in registry are loaded.
+
+To use this feature, create similar setreg file in you project's Registry:
+
+```bash
+cd ${MY_PROJECT_ROOT}/Registry
+touch watchdog.setreg
+``` 
+
+with the following content:
+
+```json
+{
+    "O3DE": {
+        "Watchdog": {
+            "RequiredComponents": [
+                "ROS2SystemComponent",
+                "MyExampleRequiredComponent"
+            ]
+        }
+    }
+}
+```
+
+To perform verification, use `WatchdogTools::WatchdogToolsRequestBus::Events::VerifyComponentsLoaded` bus.
+
+
 ## Current functionality:
 
-Currently, only implemented rule is enumerating **dynamic** modules loaded by engine and comparing it with provided list of required ones.
-This by itself helps to quickly catch multiple issues like non-sourced environment, missing required packages or messed up symlinks for 3rd party dynlibs.
+Currently, two rules are implemented:
+*   enumerating **dynamic** modules loaded by engine and comparing it with provided list of required ones. This by itself helps to quickly catch multiple issues like non-sourced environment, missing required packages or messed up symlinks for 3rd party dynlibs.
+*   enumerating **components** (both system and normal components are valid) loaded by engine and comparing it with provided list of required ones.
 
 I eagerly anticipate contributions that include additional rules.
 
 ### Rules:
 `O3DE/Watchdog/RequiredModules` - it accepts a list of required dynamic modules. Note that both prefix (lib) and suffix (.so) are optional
+`O3DE/Watchdog/RequiredComponents` - it accepts a list of required components. 
 


### PR DESCRIPTION
This PR adds a rule, which allows to check if all components listed in setreg file are present in runtime. It extends (with small adjustments) current API.