### PR TITLE
Add frame and wgs support to pose control

### DIFF
--- a/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlConfiguration.h
+++ b/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlConfiguration.h
@@ -45,5 +45,7 @@ namespace ROS2PoseControl
 
         bool m_useTagOffset = false;
         AZStd::string m_startOffsetTag;
+
+        bool m_useWGS = false;
     };
 } // namespace ROS2PoseControl

--- a/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlConfiguration.h
+++ b/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlConfiguration.h
@@ -1,10 +1,13 @@
+
 #pragma once
 
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Math/Crc.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/string/string.h>
 #include <ROS2/Communication/TopicConfiguration.h>
+
 namespace ROS2PoseControl
 {
     //! A structure for a single ROS2 topic, a part of publisher or subscriber configuration.
@@ -20,6 +23,8 @@ namespace ROS2PoseControl
         AZ::Crc32 isTrackingModePoseMessagesVisibility() const;
 
         AZ::Crc32 isGroudOffsetVisible() const;
+
+        AZ::Crc32 isUseTagOffset() const;
 
         enum class TrackingMode
         {
@@ -38,6 +43,7 @@ namespace ROS2PoseControl
         bool m_clampToGround = false;
         float m_groundOffset = 0.0f;
 
+        bool m_useTagOffset = false;
         AZStd::string m_startOffsetTag;
     };
 } // namespace ROS2PoseControl

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -165,7 +165,11 @@ namespace ROS2PoseControl
 
         // Get the transform from the PoseStamped message
         AZ::Transform transform = ROS2::ROS2Conversions::FromROS2Pose(msg->pose);
-
+        if (msg->header.frame_id.empty())
+        {
+            return AZ::Success(transform);
+        }
+        
         // Get the transform from the global frame to the frame in the PoseStamped message
         const auto globalFrameTransform = GetTF2Transform(m_odomFrameId, msg->header.frame_id.c_str());
         if (!globalFrameTransform.IsSuccess())

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -1,29 +1,24 @@
+
 #include "ROS2PoseControl.h"
+
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/Transform.h>
-#include <AzCore/Script/ScriptTimePoint.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
-#include <imgui/imgui.h>
-
-#include <ROS2/Frame/ROS2FrameComponent.h>
-#include <ROS2/ROS2Bus.h>
-#include <ROS2/Utilities/ROS2Conversions.h>
-#include <ROS2/Utilities/ROS2Names.h>
-#include <ROS2PoseControl/ROS2PoseControlConfiguration.h>
-#include <tf2_ros/transform_listener.h>
-
-#include <AzCore/std/string/regex.h>
 #include <AzFramework/Entity/GameEntityContextComponent.h>
-#include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <RigidBodyComponent.h>
-
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <LmbrCentral/Scripting/TagComponentBus.h>
+#include <ROS2/Frame/ROS2FrameComponent.h>
+#include <ROS2/Utilities/ROS2Conversions.h>
+#include <ROS2/Utilities/ROS2Names.h>
+#include <ROS2PoseControl/ROS2PoseControlConfiguration.h>
+#include <RigidBodyComponent.h>
+#include <imgui/imgui.h>
+#include <tf2_ros/transform_listener.h>
 
 namespace ROS2PoseControl
 {
@@ -43,23 +38,39 @@ namespace ROS2PoseControl
     void ROS2PoseControl::Activate()
     {
         auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
+        m_tf_buffer = std::make_unique<tf2_ros::Buffer>(ros2Node->get_clock());
+        m_tf_listener = std::make_shared<tf2_ros::TransformListener>(*m_tf_buffer);
+
         if (m_configuration.m_tracking_mode == ROS2PoseControlConfiguration::TrackingMode::TF2)
         {
-            m_tf_buffer = std::make_unique<tf2_ros::Buffer>(ros2Node->get_clock());
-            m_tf_listener = std::make_shared<tf2_ros::TransformListener>(*m_tf_buffer);
             AZ::TickBus::Handler::BusConnect();
         }
         else if (m_configuration.m_tracking_mode == ROS2PoseControlConfiguration::TrackingMode::PoseMessages)
         {
-            OnTopicConfigurationChanged();
+            // Get odom frame Id
+            const auto* ros2_frame_component = m_entity->FindComponent<ROS2::ROS2FrameComponent>();
+            if (!ros2_frame_component)
+            {
+                AZ_Error("ROS2PoseControl", false, "ROS2PoseControl requires a ROS2FrameComponent to be present on the entity.");
+                return;
+            }
+            m_odomFrameId = ros2_frame_component->GetGlobalFrameName();
+
+            // Initialize the pose subscription
+            auto namespaced_topic_name =
+                ROS2::ROS2Names::GetNamespacedName(ros2_frame_component->GetNamespace(), m_configuration.m_poseTopicConfiguration.m_topic);
+
+            m_poseSubscription = ros2Node->create_subscription<geometry_msgs::msg::PoseStamped>(
+                namespaced_topic_name.data(),
+                m_configuration.m_poseTopicConfiguration.GetQoS(),
+                [this](geometry_msgs::msg::PoseStamped::SharedPtr msg)
+                {
+                    OnPoseMessageReceived(msg);
+                }
+
+            );
         }
         ImGui::ImGuiUpdateListenerBus::Handler::BusConnect();
-
-        AZ::TickBus::QueueFunction(
-            [this]()
-            {
-                ApplyTransform(AZ::Transform::CreateIdentity());
-            });
     }
 
     void ROS2PoseControl::Deactivate()
@@ -71,126 +82,132 @@ namespace ROS2PoseControl
         ImGui::ImGuiUpdateListenerBus::Handler::BusDisconnect();
     }
 
+    void ROS2PoseControl::EnablePhysics()
+    {
+        SetPhysicsEnabled(true);
+    }
+
     void ROS2PoseControl::DisablePhysics()
     {
-        if (auto* rigidBodyComponent = m_entity->FindComponent<PhysX::RigidBodyComponent>())
+        SetPhysicsEnabled(false);
+    }
+
+    void ROS2PoseControl::SetPhysicsEnabled(bool enabled)
+    {
+        AZStd::vector<AZ::EntityId> entityIds;
+        AZ::TransformBus::EventResult(entityIds, GetEntityId(), &AZ::TransformBus::Events::GetAllDescendants);
+        entityIds.push_back(GetEntityId());
+        for (const AZ::EntityId& entityId : entityIds)
         {
-            rigidBodyComponent->DisablePhysics();
-        }
-        AZStd::vector<AZ::EntityId> children;
-        AZ::TransformBus::EventResult(children, GetEntityId(), &AZ::TransformBus::Events::GetAllDescendants);
-        for (const AZ::EntityId& child : children)
-        {
-            AZ::Entity* childEntity;
-            AZ::ComponentApplicationBus::BroadcastResult(childEntity, &AZ::ComponentApplicationRequests::FindEntity, child);
-            if (auto* childRigidBodyComponent = childEntity->FindComponent<PhysX::RigidBodyComponent>())
+            AZ::Entity* entity;
+            AZ::ComponentApplicationBus::BroadcastResult(entity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
+            if (auto* rigidBodyComponent = entity->FindComponent<PhysX::RigidBodyComponent>())
             {
-                childRigidBodyComponent->DisablePhysics();
+                if (enabled)
+                {
+                    if (m_needsPhysicsReenable.contains(entityId))
+                    {
+                        rigidBodyComponent->EnablePhysics();
+                        m_needsPhysicsReenable.erase(entityId);
+                    }
+                }
+                else
+                {
+                    if (rigidBodyComponent->IsPhysicsEnabled())
+                    {
+                        m_needsPhysicsReenable.insert(entityId);
+                        rigidBodyComponent->DisablePhysics();
+                    }
+                }
             }
         }
     }
 
-    AZ::Outcome<AZ::Transform, const char*> ROS2PoseControl::GetCurrentTransformViaTF2()
+    AZ::Outcome<AZ::Transform, void> ROS2PoseControl::GetCurrentTransformViaTF2()
+    {
+        return GetTF2Transform(m_configuration.m_referenceFrame, m_configuration.m_targetFrame);
+    }
+
+    AZ::Outcome<AZ::Transform, void> ROS2PoseControl::GetTF2Transform(const AZStd::string& targetFrame, const AZStd::string& sourceFrame)
     {
         geometry_msgs::msg::TransformStamped transformStamped;
         std::string errorString;
-        if (m_tf_buffer->canTransform(
-                m_configuration.m_referenceFrame.c_str(), m_configuration.m_targetFrame.c_str(), tf2::TimePointZero, &errorString))
+        // Check if the transform can be completed. If so return it.
+        if (m_tf_buffer->canTransform(targetFrame.c_str(), sourceFrame.c_str(), tf2::TimePointZero, &errorString))
         {
-            transformStamped = m_tf_buffer->lookupTransform(
-                m_configuration.m_referenceFrame.c_str(), m_configuration.m_targetFrame.c_str(), tf2::TimePointZero);
-            m_tf2WarningShown = false;
+            transformStamped = m_tf_buffer->lookupTransform(targetFrame.c_str(), sourceFrame.c_str(), tf2::TimePointZero);
         }
         else
         {
-            if (!m_tf2WarningShown)
-            {
-                AZ_Warning(
-                    "ROS2PositionControl",
-                    false,
-                    "Could not transform %s to %s, error: %s",
-                    m_configuration.m_targetFrame.c_str(),
-                    m_configuration.m_referenceFrame.c_str(),
-                    errorString.c_str());
-                m_tf2WarningShown = true;
-            }
-            return AZ::Failure("Could not transform");
+            AZ_Warning(
+                "ROS2PositionControl",
+                false,
+                "Could not transform %s to %s, error: %s",
+                m_configuration.m_targetFrame.c_str(),
+                m_configuration.m_referenceFrame.c_str(),
+                errorString.c_str());
+            return AZ::Failure();
         }
+
         const AZ::Quaternion rotation = ROS2::ROS2Conversions::FromROS2Quaternion(transformStamped.transform.rotation);
         const AZ::Vector3 translation = ROS2::ROS2Conversions::FromROS2Vector3(transformStamped.transform.translation);
         return AZ::Success(AZ::Transform::CreateFromQuaternionAndTranslation(rotation, translation));
+    }
+
+    AZ::Outcome<AZ::Transform, void> ROS2PoseControl::GetTransformFromPoseStamped(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+    {
+        if (!msg)
+        {
+            return AZ::Failure();
+        }
+
+        // Get the transform from the PoseStamped message
+        AZ::Transform transform = ROS2::ROS2Conversions::FromROS2Pose(msg->pose);
+
+        // Get the transform from the global frame to the frame in the PoseStamped message
+        const auto globalFrameTransform = GetTF2Transform(m_odomFrameId, msg->header.frame_id.c_str());
+        if (!globalFrameTransform.IsSuccess())
+        {
+            return AZ::Failure();
+        }
+
+        // Apply the global frame transform to the transform from the PoseStamped message
+        transform = globalFrameTransform.GetValue() * transform;
+
+        return AZ::Success(transform);
+    }
+
+    void ROS2PoseControl::OnPoseMessageReceived(const geometry_msgs::msg::PoseStamped::SharedPtr msg)
+    {
+        if (m_configuration.m_tracking_mode != ROS2PoseControlConfiguration::TrackingMode::PoseMessages)
+        {
+            return;
+        }
+        auto targetTransform = GetTransformFromPoseStamped(msg);
+        if (targetTransform.IsSuccess())
+        {
+            ApplyTransform(targetTransform.GetValue());
+        }
     }
 
     void ROS2PoseControl::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
         if (m_configuration.m_tracking_mode == ROS2PoseControlConfiguration::TrackingMode::TF2)
         {
-            const AZ::Outcome<AZ::Transform, const char*> transform_outcome = GetCurrentTransformViaTF2();
+            const AZ::Outcome<AZ::Transform, void> transform_outcome = GetCurrentTransformViaTF2();
             if (!transform_outcome.IsSuccess())
             {
                 return;
             }
-            else
-            {
-                ApplyTransform(transform_outcome.GetValue());
-            }
+            ApplyTransform(transform_outcome.GetValue());
         }
-    }
-
-    void ROS2PoseControl::OnTopicConfigurationChanged()
-    {
-        if (m_configuration.m_tracking_mode != ROS2PoseControlConfiguration::TrackingMode::PoseMessages)
-        {
-            return;
-        }
-        auto ros2Node = ROS2::ROS2Interface::Get()->GetNode();
-        const auto* ros2_frame_component = m_entity->FindComponent<ROS2::ROS2FrameComponent>();
-        auto namespaced_topic_name =
-            ROS2::ROS2Names::GetNamespacedName(ros2_frame_component->GetNamespace(), m_configuration.m_poseTopicConfiguration.m_topic);
-        m_poseSubscription = ros2Node->create_subscription<geometry_msgs::msg::PoseStamped>(
-            namespaced_topic_name.data(),
-            m_configuration.m_poseTopicConfiguration.GetQoS(),
-            [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg)
-            {
-                if (m_configuration.m_tracking_mode != ROS2PoseControlConfiguration::TrackingMode::PoseMessages || !m_isTracking)
-                {
-                    return;
-                }
-                const AZ::Transform transform = ROS2::ROS2Conversions::FromROS2Pose(msg->pose);
-                //                AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, transform);
-                ApplyTransform(transform);
-            });
-    }
-
-    void ROS2PoseControl::OnIsTrackingChanged()
-    {
-        if (m_configuration.m_tracking_mode == ROS2PoseControlConfiguration::TrackingMode::TF2)
-        {
-            if (m_isTracking)
-            {
-                AZ::TickBus::Handler::BusConnect();
-            }
-            else
-            {
-                AZ::TickBus::Handler::BusDisconnect();
-            }
-        }
-    }
-
-    void ROS2PoseControl::SetIsTracking(const bool isTracking)
-    {
-        m_isTracking = isTracking;
-        OnIsTrackingChanged();
     }
 
     void ROS2PoseControl::Reflect(AZ::ReflectContext* context)
     {
         if (auto* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serialize->Class<ROS2PoseControl, AZ::Component>()
-                ->Version(1)
-                ->Field("m_isTracking", &ROS2PoseControl::m_isTracking)
-                ->Field("m_configuration", &ROS2PoseControl::m_configuration);
+            serialize->Class<ROS2PoseControl, AZ::Component>()->Version(1)->Field("m_configuration", &ROS2PoseControl::m_configuration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
             {
@@ -198,8 +215,6 @@ namespace ROS2PoseControl
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "ROS2PoseControl")
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Game"))
                     ->Attribute(AZ::Edit::Attributes::Category, "ROS2")
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &ROS2PoseControl::m_isTracking, "Is Tracking", "Turn the tracking on or off")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2PoseControl::m_configuration,
@@ -214,10 +229,6 @@ namespace ROS2PoseControl
         std::stringstream ss;
         ss << "ROS2PoseControl Entity: " << GetEntity()->GetName().c_str() << " , Id: " << GetEntityId().ToString().c_str();
         ImGui::Begin(ss.str().c_str());
-        if (ImGui::Checkbox("Is Tracking", &m_isTracking))
-        {
-            OnIsTrackingChanged();
-        }
         ImGui::Checkbox("Lock Z Axis", &m_configuration.m_lockZAxis);
         ImGui::Checkbox("Clamp to Ground", &m_configuration.m_clampToGround);
         ImGui::Text(
@@ -274,41 +285,38 @@ namespace ROS2PoseControl
     AZStd::optional<AZ::Transform> ROS2PoseControl::GetOffsetTransform(const AZStd::string& tagName)
     {
         AZStd::optional<AZ::Transform> offsetTransform = AZStd::nullopt;
+
         AZ::EBusAggregateResults<AZ::EntityId> aggregator;
         const LmbrCentral::Tag tag = AZ::Crc32(tagName);
         LmbrCentral::TagGlobalRequestBus::EventResult(aggregator, tag, &LmbrCentral::TagGlobalRequests::RequestTaggedEntities);
-        if (!m_groundNotFoundWarningShown)
-        {
-            AZ_Warning(
-                "ROS2PoseControl",
-                aggregator.values.size() <= 1,
-                "Multiple entities found with tag %s. The first entity will be used.",
-                tagName.c_str());
 
-            AZ_Warning("ROS2PoseControl", !aggregator.values.empty(), "No entity with tag found %s.", tagName.c_str());
-            m_groundNotFoundWarningShown = aggregator.values.size() != 1;
-        }
-        if (aggregator.values.size() == 1)
-        {
-            m_groundNotFoundWarningShown = false;
-        }
+        AZ_Warning(
+            "ROS2PoseControl",
+            aggregator.values.size() <= 1,
+            "Multiple entities found with tag \"%s\". The first entity will be used.",
+            tagName.c_str());
+
         if (!aggregator.values.empty())
         {
             const AZ::EntityId& entityId = aggregator.values[0];
             AZ::TransformBus::EventResult(offsetTransform, entityId, &AZ::TransformBus::Events::GetWorldTM);
         }
+        AZ_Warning(
+            "ROS2PoseControl",
+            !aggregator.values.empty(),
+            "No entity with tag \"%s\" was found. No offset will be applied.",
+            tagName.c_str());
 
         return offsetTransform;
     }
 
     void ROS2PoseControl::ApplyTransform(const AZ::Transform& transform)
     {
-        if (!m_isPhysicsDisabled)
-        {
-            DisablePhysics();
-            m_isPhysicsDisabled = true;
-        }
+        // Disable physics to allow transform movement.
+        DisablePhysics();
+
         AZ::Transform modifiedTransform = m_configuration.m_lockZAxis ? RemoveTilt(transform) : transform;
+
         if (!m_configuration.m_startOffsetTag.empty())
         {
             auto startOffsetTransform = GetOffsetTransform(m_configuration.m_startOffsetTag);
@@ -317,6 +325,7 @@ namespace ROS2PoseControl
                 modifiedTransform = startOffsetTransform.value() * modifiedTransform;
             }
         }
+
         if (m_configuration.m_clampToGround)
         {
             constexpr float maxDistance = 40.0f;
@@ -329,7 +338,11 @@ namespace ROS2PoseControl
                 modifiedTransform.SetTranslation(hitPosition.value() - gravityDirection * m_configuration.m_groundOffset);
             }
         }
+
         AZ::TransformBus::Event(GetEntityId(), &AZ::TransformBus::Events::SetWorldTM, modifiedTransform);
+
+        // Re-enable physics after the transform is applied.
+        EnablePhysics();
     }
 
     AZStd::optional<AZ::Vector3> ROS2PoseControl::QueryGround(
@@ -358,16 +371,12 @@ namespace ROS2PoseControl
         request.m_distance = maxDistance;
 
         AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
-        if (!m_groundNotFoundWarningShown)
-        {
-            AZ_Warning("ROS2PoseControl", hitPosition.has_value(), "No ground found for the entity");
-            m_groundNotFoundWarningShown = !hitPosition.has_value();
-        }
-        m_groundNotFoundWarningShown = hitPosition.has_value();
+
         if (!result.m_hits.empty())
         {
             hitPosition = result.m_hits.front().m_position;
         }
+
         return hitPosition;
     }
 

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -169,7 +169,7 @@ namespace ROS2PoseControl
         {
             return AZ::Success(transform);
         }
-        
+
         // Get the transform from the global frame to the frame in the PoseStamped message
         const auto globalFrameTransform = GetTF2Transform(m_odomFrameId, msg->header.frame_id.c_str());
         if (!globalFrameTransform.IsSuccess())

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
@@ -39,7 +39,8 @@ namespace ROS2PoseControl
                 ->Field("useTagOffset", &ROS2PoseControlConfiguration::m_useTagOffset)
                 ->Field("startOffsetTag", &ROS2PoseControlConfiguration::m_startOffsetTag)
                 ->Field("m_clampToGround", &ROS2PoseControlConfiguration::m_clampToGround)
-                ->Field("m_groundOffset", &ROS2PoseControlConfiguration::m_groundOffset);
+                ->Field("m_groundOffset", &ROS2PoseControlConfiguration::m_groundOffset)
+                ->Field("useWGS", &ROS2PoseControlConfiguration::m_useWGS);
 
             if (AZ::EditContext* ec = serializeContext->GetEditContext())
             {
@@ -53,6 +54,12 @@ namespace ROS2PoseControl
                     ->EnumAttribute(TrackingMode::PoseMessages, "Pose Messages")
                     ->EnumAttribute(TrackingMode::TF2, "TF2")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2PoseControlConfiguration::m_useWGS,
+                        "Enable support for WGS84",
+                        "Enable support for WGS84")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isTrackingModePoseMessagesVisibility)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2PoseControlConfiguration::m_poseTopicConfiguration,
@@ -86,6 +93,7 @@ namespace ROS2PoseControl
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isUseTagOffset)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &ROS2PoseControlConfiguration::m_clampToGround, "Clamp to Ground", "Clamp to ground")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2PoseControlConfiguration::m_groundOffset,

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
@@ -1,5 +1,7 @@
-#include <AzCore/Serialization/EditContext.h>
+
 #include <ROS2PoseControl/ROS2PoseControlConfiguration.h>
+
+#include <AzCore/Serialization/EditContext.h>
 
 namespace ROS2PoseControl
 {
@@ -18,6 +20,11 @@ namespace ROS2PoseControl
         return m_clampToGround ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
     }
 
+    AZ::Crc32 ROS2PoseControlConfiguration::isUseTagOffset() const
+    {
+        return m_useTagOffset ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+    }
+
     void ROS2PoseControlConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
@@ -29,6 +36,7 @@ namespace ROS2PoseControl
                 ->Field("m_targetFrame", &ROS2PoseControlConfiguration::m_targetFrame)
                 ->Field("m_referenceFrame", &ROS2PoseControlConfiguration::m_referenceFrame)
                 ->Field("lockZAxis", &ROS2PoseControlConfiguration::m_lockZAxis)
+                ->Field("useTagOffset", &ROS2PoseControlConfiguration::m_useTagOffset)
                 ->Field("startOffsetTag", &ROS2PoseControlConfiguration::m_startOffsetTag)
                 ->Field("m_clampToGround", &ROS2PoseControlConfiguration::m_clampToGround)
                 ->Field("m_groundOffset", &ROS2PoseControlConfiguration::m_groundOffset);
@@ -66,9 +74,16 @@ namespace ROS2PoseControl
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2PoseControlConfiguration::m_lockZAxis, "Lock Z Axis", "Lock Z axis")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
+                        &ROS2PoseControlConfiguration::m_useTagOffset,
+                        "Use Tag Offset",
+                        "Use a tag that will be used to set the start offset for the entity.")
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
                         &ROS2PoseControlConfiguration::m_startOffsetTag,
                         "Start Offset Tag",
                         "Tag that will be used to set the start offset for the entity.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isUseTagOffset)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &ROS2PoseControlConfiguration::m_clampToGround, "Clamp to Ground", "Clamp to ground")
                     ->DataElement(


### PR DESCRIPTION
I've added support for pose-stamped messages in ROS2PoseControl. In addition, I've added support for WGS84 coordinate system.

These changes resolve #https://github.com/RobotecAI/robotec-o3de-tools/issues/22.
These changes are based on the discussion present in https://github.com/RobotecAI/robotec-o3de-tools/pull/35.

I'm opening a new branch as the other one is quite old and this one contains a small refactor.

The pose control now queries the TF tree looking for a valid transform between a frame contained in the pose-stamped message and the global frame in o3de. It applies the pose from the pose-stamped to the found transform and moves the object in the scene. An empty frame will interpret the pose as O3DE world coordinates.

The WGS84 support works when the frame id in the message is `wgs84` and the geopositioning component is present in the level.