### PR TITLE
Fix variant spawner index out of range error

### DIFF
--- a/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
+++ b/Gems/LevelModificationTools/Code/Source/Clients/PrefabVariantComponent.cpp
@@ -37,19 +37,15 @@ namespace LevelModificationTools
 
     void PrefabVariantComponent::SetPrefabVariant(AZ::s32 variantId)
     {
-        if (variantId < 0 && variantId >= m_config.m_prefabVariants.size())
+        if (variantId < 0 || variantId >= m_config.m_prefabVariants.size())
         {
             m_spawnTicket = AzFramework::EntitySpawnTicket();
+            AZ_Warning("PrefabVariantComponent", false, "Prefab variant with id %d not found.", variantId);
             return;
         }
 
         const auto assetIter = m_config.m_prefabVariants.begin() + variantId;
-        AZ_Warning(
-            "PrefabVariantComponent", assetIter != m_config.m_prefabVariants.end(), "Prefab variant with id %d not found.", variantId);
-        if (assetIter != m_config.m_prefabVariants.end())
-        {
-            m_spawnTicket = SpawnPrefab(*assetIter, GetEntityId());
-        }
+        m_spawnTicket = SpawnPrefab(*assetIter, GetEntityId());
     }
 
     void PrefabVariantComponent::Reflect(AZ::ReflectContext* context)


### PR DESCRIPTION
An `&&` operator was used thus making the if statement always false and creating crashes when selecting variant out of range.
Changed to `||`.

In addition, I removed unnecessary code that rechecked these conditions.