### PR TITLE
Fixed assert in the CsvSpawner

### DIFF
--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerUtils.cpp
@@ -157,7 +157,7 @@ namespace CsvSpawner::CsvSpawnerUtils
     {
         AZStd::optional<AZ::Vector3> hitPosition = AZStd::nullopt;
 
-        AZ_Assert(sceneHandle == AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
+        AZ_Assert(sceneHandle != AzPhysics::InvalidSceneHandle, "Unable to get  scene handle");
         if (sceneHandle == AzPhysics::InvalidSceneHandle)
         {
             return hitPosition;


### PR DESCRIPTION
Fixed an incorrectly defined condition in AZ_Assert to avoid false positive asserts visible in the console, as the assert should be triggered by the `false' evaluation of the condition.