### PR TITLE
GeoJSON - fix spawning when the terrain is included

### DIFF
--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -30,6 +30,7 @@ namespace GeoJSONSpawner
     inline constexpr const char* GeoJSONSpawnableAssetConfigurationTypeId = "{cee254bb-edc8-45b1-b85a-aaf19ec3af83}";
     inline constexpr const char* GeoJSONSpawnableEntityInfoTypeId = "{170bb487-fbae-4394-8176-069045a3a316}";
     inline constexpr const char* FeatureObjectInfoTypeId = "{00f38302-9f4d-4bac-805b-72a29e42a704}";
+    inline constexpr const char* GeoJSONSpawnerEditorTerrainSettingsConfigTypeId = "{9bb9e1c6-dd7c-435f-8fe1-bd5498c3e8f2}";
 
     // Components TypeIds
     inline constexpr const char* GeoJSONSpawnerComponentTypeId = "{839ede69-92f1-45b0-a60e-035d0b84e1fd}";

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
@@ -21,14 +21,6 @@ namespace GeoJSONSpawner
         auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
         {
-            // Reflect the enum - this crashesh reflect
-            // serializeContext->Enum<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>()
-            //     ->Value("None", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None)
-            //     ->Value("Settings", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings)
-            //     ->Value("HeightData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData)
-            //     ->Value("ColorData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData)
-            //     ->Value("All", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All);
-
             serializeContext->Class<GeoJSONSpawnerEditorTerrainSettingsConfig>()
                 ->Version(0)
                 ->Field("SpawnOnComponentActivated", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnComponentActivated)
@@ -137,11 +129,6 @@ namespace GeoJSONSpawner
 
     AZ::Crc32 GeoJSONSpawnerEditorTerrainSettingsConfig::SpawnOnTerrainUpdateTriggered()
     {
-        if (IsSpawnOnTerrainUpdateDisabled())
-        {
-            m_terrainMasksToIgnore = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All;
-        }
-
         return RefreshUI();
     }
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Robotec AI - All Rights Reserved
+ * Copyright (C) Robotec AI - All Rights Reserved
  *
  * This source code is protected under international copyright law.  All rights
  * reserved and protected by the copyright holders.
@@ -65,7 +65,8 @@ namespace GeoJSONSpawner
                 ->Attribute(AZ::Edit::Attributes::ReadOnly, &GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateDisabled)
                 ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorTerrainSettingsConfig::OnTerrainFlagsChanged)
                 ->Attribute(AZ::Edit::Attributes::Visibility, &GeoJSONSpawnerEditorTerrainSettingsConfig::SetPropertyVisibilityByTerrain)
-                ->Attribute(AZ::Edit::Attributes::ComboBoxEditable, &GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateEnabled)
+                ->Attribute(
+                    AZ::Edit::Attributes::ComboBoxEditable, &GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateEnabled)
                 ->Attribute(
                     AZ::Edit::Attributes::EnumValues,
                     AZStd::vector<AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>>{
@@ -168,4 +169,4 @@ namespace GeoJSONSpawner
     {
         return m_spawnOnTerrainUpdate;
     }
-} // GeoJSON
+} // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
@@ -21,16 +21,16 @@ namespace GeoJSONSpawner
         auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
         if (serializeContext)
         {
-            // Reflect the enum
-            serializeContext->Enum<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>()
-                ->Value("None", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None)
-                ->Value("Settings", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings)
-                ->Value("HeightData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData)
-                ->Value("ColorData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData)
-                ->Value("All", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All);
+            // Reflect the enum - this crashesh reflect
+            // serializeContext->Enum<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>()
+            //     ->Value("None", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None)
+            //     ->Value("Settings", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings)
+            //     ->Value("HeightData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData)
+            //     ->Value("ColorData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData)
+            //     ->Value("All", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All);
 
             serializeContext->Class<GeoJSONSpawnerEditorTerrainSettingsConfig>()
-                ->Version(2)
+                ->Version(0)
                 ->Field("SpawnOnComponentActivated", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnComponentActivated)
                 ->Field("SpawnOnTerrainUpdate", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnTerrainUpdate)
                 ->Field("TerrainDataChangedMask", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_terrainMasksToIgnore);

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
@@ -9,10 +9,10 @@
  */
 
 #include "GeoJSONSpawnerEditorTerrainSettingsConfig.h"
-
-#include "AzCore/Serialization/EditContext.h"
-#include "AzCore/Serialization/SerializeContext.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerUtils.h"
+
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
@@ -1,0 +1,171 @@
+/**
+* Copyright (C) Robotec AI - All Rights Reserved
+ *
+ * This source code is protected under international copyright law.  All rights
+ * reserved and protected by the copyright holders.
+ * This file is confidential and only available to authorized individuals with the
+ * permission of the copyright holders.  If you encounter this file and do not have
+ * permission, please contact the copyright holders and delete this file.
+ */
+
+#include "GeoJSONSpawnerEditorTerrainSettingsConfig.h"
+
+#include "AzCore/Serialization/EditContext.h"
+#include "AzCore/Serialization/SerializeContext.h"
+#include "GeoJSONSpawner/GeoJSONSpawnerUtils.h"
+
+namespace GeoJSONSpawner
+{
+    void GeoJSONSpawnerEditorTerrainSettingsConfig::Reflect(AZ::ReflectContext* context)
+    {
+        auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context);
+        if (serializeContext)
+        {
+            // Reflect the enum
+            serializeContext->Enum<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>()
+                ->Value("None", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None)
+                ->Value("Settings", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings)
+                ->Value("HeightData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData)
+                ->Value("ColorData", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData)
+                ->Value("All", AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All);
+
+            serializeContext->Class<GeoJSONSpawnerEditorTerrainSettingsConfig>()
+                ->Version(2)
+                ->Field("SpawnOnComponentActivated", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnComponentActivated)
+                ->Field("SpawnOnTerrainUpdate", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnTerrainUpdate)
+                ->Field("TerrainDataChangedMask", &GeoJSONSpawnerEditorTerrainSettingsConfig::m_terrainMasksToIgnore);
+        }
+
+        auto* editContext = serializeContext->GetEditContext();
+        if (editContext)
+        {
+            editContext
+                ->Class<GeoJSONSpawnerEditorTerrainSettingsConfig>(
+                    "GeoJSONSpawnerEditorTerrainSettingsConfig", "GeoJSONSpawnerEditorTerrainSettingsConfig")
+                ->ClassElement(AZ::Edit::ClassElements::EditorData, "In Editor Spawn Settings")
+                ->Attribute(AZ::Edit::Attributes::Category, "In Editor Spawn Settings")
+                ->DataElement(
+                    AZ::Edit::UIHandlers::Default,
+                    &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnComponentActivated,
+                    "Spawn On Editor Activate",
+                    "Spawns entities when editor component is being activated.")
+                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorTerrainSettingsConfig::RefreshUI)
+                ->DataElement(
+                    AZ::Edit::UIHandlers::Default,
+                    &GeoJSONSpawnerEditorTerrainSettingsConfig::m_spawnOnTerrainUpdate,
+                    "Spawn On Terrain Update",
+                    "Should respawn entities on any Terrain config and transform change.")
+                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorTerrainSettingsConfig::SpawnOnTerrainUpdateTriggered)
+                ->Attribute(AZ::Edit::Attributes::Visibility, &GeoJSONSpawnerEditorTerrainSettingsConfig::SetPropertyVisibilityByTerrain)
+                ->DataElement(
+                    AZ::Edit::UIHandlers::ComboBox,
+                    &GeoJSONSpawnerEditorTerrainSettingsConfig::m_terrainMasksToIgnore,
+                    "Terrain Flags To Ignore",
+                    "Flags to ignore on the terrain update data performed.")
+                ->Attribute(AZ::Edit::Attributes::ReadOnly, &GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateDisabled)
+                ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorTerrainSettingsConfig::OnTerrainFlagsChanged)
+                ->Attribute(AZ::Edit::Attributes::Visibility, &GeoJSONSpawnerEditorTerrainSettingsConfig::SetPropertyVisibilityByTerrain)
+                ->Attribute(AZ::Edit::Attributes::ComboBoxEditable, &GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateEnabled)
+                ->Attribute(
+                    AZ::Edit::Attributes::EnumValues,
+                    AZStd::vector<AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>>{
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::None, "None"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All, "All"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings, "Settings"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData, "Height Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData, "Color Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData, "Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData,
+                            "Settings + Height Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData,
+                            "Settings + Color Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Settings + Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData,
+                            "Height Data + Color Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Height Data + Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Color Data + Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData,
+                            "Settings + Height Data + Color Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Settings + Height Data + Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Settings + Color Data + Surface Data"),
+                        AZ::Edit::EnumConstant<AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask>(
+                            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::HeightData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData |
+                                AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::SurfaceData,
+                            "Height Data + Color Data + Surface Data"),
+                    });
+        }
+    }
+
+    AZ::u32 GeoJSONSpawnerEditorTerrainSettingsConfig::SetPropertyVisibilityByTerrain() const
+    {
+        return GeoJSONUtils::IsTerrainAvailable() ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+    }
+
+    AZ::Crc32 GeoJSONSpawnerEditorTerrainSettingsConfig::SpawnOnTerrainUpdateTriggered()
+    {
+        if (IsSpawnOnTerrainUpdateDisabled())
+        {
+            m_terrainMasksToIgnore = AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All;
+        }
+
+        return RefreshUI();
+    }
+
+    AZ::Crc32 GeoJSONSpawnerEditorTerrainSettingsConfig::OnTerrainFlagsChanged()
+    {
+        if (m_terrainMasksToIgnore == AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::All)
+        {
+            m_spawnOnTerrainUpdate = false;
+        }
+
+        return RefreshUI();
+    }
+
+    AZ::Crc32 GeoJSONSpawnerEditorTerrainSettingsConfig::RefreshUI()
+    {
+        return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
+    }
+
+    bool GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateDisabled() const
+    {
+        return !m_spawnOnTerrainUpdate;
+    }
+
+    bool GeoJSONSpawnerEditorTerrainSettingsConfig::IsSpawnOnTerrainUpdateEnabled() const
+    {
+        return m_spawnOnTerrainUpdate;
+    }
+} // GeoJSON

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "AzCore/RTTI/ReflectContext.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
@@ -1,0 +1,62 @@
+/**
+* Copyright (C) Robotec AI - All Rights Reserved
+ *
+ * This source code is protected under international copyright law.  All rights
+ * reserved and protected by the copyright holders.
+ * This file is confidential and only available to authorized individuals with the
+ * permission of the copyright holders.  If you encounter this file and do not have
+ * permission, please contact the copyright holders and delete this file.
+ */
+
+#pragma once
+
+#include "AzCore/RTTI/ReflectContext.h"
+#include "AzCore/RTTI/RTTIMacros.h"
+#include "AzFramework/Terrain/TerrainDataRequestBus.h"
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+
+namespace GeoJSONSpawner
+{
+    //! Terrain Settings Configuration for Editor Component.
+    //! This config lets user decide what behaviour should be applied when the Terrain is applicable in current Level.
+    class GeoJSONSpawnerEditorTerrainSettingsConfig
+    {
+    public:
+        AZ_RTTI(GeoJSONSpawnerEditorTerrainSettingsConfig, GeoJSONSpawnerEditorTerrainSettingsConfigTypeId)
+
+        GeoJSONSpawnerEditorTerrainSettingsConfig() = default;
+        virtual ~GeoJSONSpawnerEditorTerrainSettingsConfig() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        //! Whether entities should be spawned if editor component is activated.
+        bool m_spawnOnComponentActivated{ true };
+
+        //! Prevent multiple terrains to init spawn. @returns True if spawned once, false otherwise.
+        bool m_flagSpawnEntitiesOnStartOnce{ false };
+
+        //! Whether Terrain settings or position is updated, and if should spawned entities follow up the changes.
+        bool m_spawnOnTerrainUpdate{ false };
+
+        //! Masks to be ignored while updating Terrain.
+        AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask m_terrainMasksToIgnore{
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::Settings |
+            AzFramework::Terrain::TerrainDataNotifications::TerrainDataChangedMask::ColorData
+        };
+
+    private:
+        AZ::u32 SetPropertyVisibilityByTerrain() const;
+
+        AZ::Crc32 SpawnOnTerrainUpdateTriggered();
+
+        AZ::Crc32 OnTerrainFlagsChanged();
+
+        AZ::Crc32 RefreshUI();
+
+        // Helper functions for UI Notify (need both, since cannot negate them in Reflect)
+        [[nodiscard]] bool IsSpawnOnTerrainUpdateDisabled() const;
+        [[nodiscard]] bool IsSpawnOnTerrainUpdateEnabled() const;
+    };
+
+} // GeoJSON
+

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "AzCore/RTTI/RTTIMacros.h"
 #include "AzCore/RTTI/ReflectContext.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
@@ -1,5 +1,5 @@
 /**
-* Copyright (C) Robotec AI - All Rights Reserved
+ * Copyright (C) Robotec AI - All Rights Reserved
  *
  * This source code is protected under international copyright law.  All rights
  * reserved and protected by the copyright holders.
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "AzCore/RTTI/ReflectContext.h"
 #include "AzCore/RTTI/RTTIMacros.h"
+#include "AzCore/RTTI/ReflectContext.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 
@@ -58,5 +58,4 @@ namespace GeoJSONSpawner
         [[nodiscard]] bool IsSpawnOnTerrainUpdateEnabled() const;
     };
 
-} // GeoJSON
-
+} // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "GeoJSONSpawnerUtils.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+#include "GeoJSONSpawnerUtils.h"
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include "GeoJSONSpawnerUtils.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
+#include "GeoJSONSpawnerUtils.h"
 
 #include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
 #include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -10,17 +10,15 @@
 
 #pragma once
 
-#include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "GeoJSONSpawnerUtils.h"
+#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 
-#include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
-#include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
-
-#include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzFramework/Spawnable/Spawnable.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "GeoJSONSpawnerUtils.h"
+#include "AzFramework/Terrain/TerrainDataRequestBus.h"
 
 #include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
 #include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
@@ -35,6 +36,7 @@ namespace GeoJSONSpawner
         : public AZ::Component
         , public GeoJSONSpawnerRequestBus::Handler
         , public AZ::TickBus::Handler
+        , protected AzFramework::Terrain::TerrainDataNotificationBus::Handler
     {
     public:
         AZ_COMPONENT(GeoJSONSpawnerComponent, GeoJSONSpawnerComponentTypeId);
@@ -59,6 +61,10 @@ namespace GeoJSONSpawner
         Result DeleteAll() override;
         Result DeleteById(const AZStd::unordered_set<int>& idsToDelete) override;
         GetIdsResult GetIds() const override;
+
+        // AzFramework::Terrain::TerrainDataNotificationBus overrides
+        void OnTerrainDataCreateEnd() override;
+        void OnTerrainDataDestroyBegin() override;
 
     private:
         // AZ::TickBus::Handler overrides
@@ -91,5 +97,8 @@ namespace GeoJSONSpawner
 
         SpawnerState m_spawnerState{ SpawnerState::Idle };
         AZStd::queue<SpawnerState> m_spawnerStateQueue;
+
+        // Terrain notify
+        bool m_terrainCreatedOnlyOnce{ false }; //!< Is terrain fully generated once
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -207,7 +207,8 @@ namespace GeoJSONSpawner
         m_spawnedTicketsGroups.clear();
     }
 
-    void GeoJSONSpawnerEditorComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
+    void GeoJSONSpawnerEditorComponent::OnTerrainDataChanged(
+        [[maybe_unused]] const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
         // Ignore on update with selected flags
         if (static_cast<bool>(dataChangedMask & m_terrainSettingsConfig.m_terrainMasksToIgnore))

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -9,7 +9,6 @@
  */
 
 #include "GeoJSONSpawnerEditorComponent.h"
-
 #include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
 #include "GeoJSONSpawnerComponent.h"
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -11,6 +11,7 @@
 #include "GeoJSONSpawnerEditorComponent.h"
 
 #include "GeoJSONSpawnerComponent.h"
+#include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
 
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Component/TransformBus.h>
@@ -25,12 +26,15 @@ namespace GeoJSONSpawner
     {
         if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
+            GeoJSONSpawnerEditorTerrainSettingsConfig::Reflect(context);
+
             serializeContext->Class<GeoJSONSpawnerEditorComponent, AzToolsFramework::Components::EditorComponentBase>()
                 ->Version(0)
                 ->Field("GeoJSONAssetId", &GeoJSONSpawnerEditorComponent::m_geoJsonAssetId)
                 ->Field("Configuration", &GeoJSONSpawnerEditorComponent::m_spawnableAssetConfigurations)
                 ->Field("DefaultSeed", &GeoJSONSpawnerEditorComponent::m_defaultSeed)
-                ->Field("ShowLabels", &GeoJSONSpawnerEditorComponent::m_showLabels);
+                ->Field("ShowLabels", &GeoJSONSpawnerEditorComponent::m_showLabels)
+                ->Field("ConfigTerrainSettings", &GeoJSONSpawnerEditorComponent::m_terrainSettingsConfig);
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())
             {
@@ -63,7 +67,12 @@ namespace GeoJSONSpawner
                         &GeoJSONSpawnerEditorComponent::m_showLabels,
                         "Show labels in Editor",
                         "Show labels in Editor.")
-                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorComponent::OnShowLabelsChanged);
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorComponent::OnShowLabelsChanged)
+                    ->DataElement(
+                            AZ::Edit::UIHandlers::Default,
+                            &GeoJSONSpawnerEditorComponent::m_terrainSettingsConfig,
+                            "Spawn Behaviour Settings",
+                            "Settings to configure spawn behaviour in editor.");
             }
         }
     }
@@ -71,22 +80,34 @@ namespace GeoJSONSpawner
     void GeoJSONSpawnerEditorComponent::Activate()
     {
         AzToolsFramework::Components::EditorComponentBase::Activate();
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusConnect();
         if (m_showLabels)
         {
             AzFramework::ViewportDebugDisplayEventBus::Handler::BusConnect(AzToolsFramework::GetEntityContextId());
         }
 
-        AZ::TickBus::QueueFunction(
-            [this]()
-            {
-                SpawnEntities();
-            });
+        if (m_terrainSettingsConfig.m_spawnOnComponentActivated && !m_terrainSettingsConfig.m_flagSpawnEntitiesOnStartOnce)
+        {
+            AZ::TickBus::QueueFunction(
+                [this]()
+                {
+                    // If there is no Terrain handlers (which means no active terrain in this level), just spawn entities on next available
+                    // tick. Since terrain is initiated on tick, IsTerrainAvailable will return real information when used inside tick.
+                    if (!GeoJSONUtils::IsTerrainAvailable() && !m_terrainSettingsConfig.m_spawnOnTerrainUpdate)
+                    {
+                        m_terrainSettingsConfig.m_flagSpawnEntitiesOnStartOnce = true;
+                        SpawnEntities();
+                    }
+                });
+        }
     }
 
     void GeoJSONSpawnerEditorComponent::Deactivate()
     {
         m_spawnedTicketsGroups.clear();
+        m_terrainSettingsConfig.m_flagSpawnEntitiesOnStartOnce = false;
 
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusDisconnect();
         AzFramework::ViewportDebugDisplayEventBus::Handler::BusDisconnect();
         AzToolsFramework::Components::EditorComponentBase::Deactivate();
     }
@@ -188,8 +209,22 @@ namespace GeoJSONSpawner
 
     void GeoJSONSpawnerEditorComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
     {
-        NonIdHandler<TerrainDataNotifications, TerrainDataNotifications, AZ::Internal::EBusContainer<TerrainDataNotifications,
-            TerrainDataNotifications>>::OnTerrainDataChanged(dirtyRegion, dataChangedMask);
+        // Ignore on update with selected flags
+        if (static_cast<bool>(dataChangedMask & m_terrainSettingsConfig.m_terrainMasksToIgnore))
+        {
+            return;
+        }
+
+        if ((m_terrainSettingsConfig.m_spawnOnComponentActivated && !m_terrainSettingsConfig.m_flagSpawnEntitiesOnStartOnce) ||
+            m_terrainSettingsConfig.m_spawnOnTerrainUpdate)
+        {
+            AZ::TickBus::QueueFunction(
+                [this]()
+                {
+                    SpawnEntities();
+                    m_terrainSettingsConfig.m_flagSpawnEntitiesOnStartOnce = true;
+                });
+        }
     }
 
     void GeoJSONSpawnerEditorComponent::DisplayViewport(

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -10,8 +10,8 @@
 
 #include "GeoJSONSpawnerEditorComponent.h"
 
-#include "GeoJSONSpawnerComponent.h"
 #include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
+#include "GeoJSONSpawnerComponent.h"
 
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Component/TransformBus.h>
@@ -69,10 +69,10 @@ namespace GeoJSONSpawner
                         "Show labels in Editor.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, &GeoJSONSpawnerEditorComponent::OnShowLabelsChanged)
                     ->DataElement(
-                            AZ::Edit::UIHandlers::Default,
-                            &GeoJSONSpawnerEditorComponent::m_terrainSettingsConfig,
-                            "Spawn Behaviour Settings",
-                            "Settings to configure spawn behaviour in editor.");
+                        AZ::Edit::UIHandlers::Default,
+                        &GeoJSONSpawnerEditorComponent::m_terrainSettingsConfig,
+                        "Spawn Behaviour Settings",
+                        "Settings to configure spawn behaviour in editor.");
             }
         }
     }

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -186,6 +186,12 @@ namespace GeoJSONSpawner
         m_spawnedTicketsGroups.clear();
     }
 
+    void GeoJSONSpawnerEditorComponent::OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask)
+    {
+        NonIdHandler<TerrainDataNotifications, TerrainDataNotifications, AZ::Internal::EBusContainer<TerrainDataNotifications,
+            TerrainDataNotifications>>::OnTerrainDataChanged(dirtyRegion, dataChangedMask);
+    }
+
     void GeoJSONSpawnerEditorComponent::DisplayViewport(
         [[maybe_unused]] const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
     {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -10,15 +10,14 @@
 
 #pragma once
 
-#include "AzFramework/Terrain/TerrainDataRequestBus.h"
-#include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
 #include "GeoJSONSpawnerUtils.h"
-
-#include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+#include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
 
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
+#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -10,14 +10,14 @@
 
 #pragma once
 
-#include "GeoJSONSpawnerUtils.h"
-#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 #include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+#include "GeoJSONSpawnerUtils.h"
 
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
-#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
+#include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include "GeoJSONSpawnerUtils.h"
+#include "AzFramework/Terrain/TerrainDataRequestBus.h"
+
 #include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
 
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
@@ -27,6 +29,7 @@ namespace GeoJSONSpawner
     class GeoJSONSpawnerEditorComponent
         : public AzToolsFramework::Components::EditorComponentBase
         , protected AzFramework::ViewportDebugDisplayEventBus::Handler
+        , protected AzFramework::Terrain::TerrainDataNotificationBus::Handler
     {
     public:
         AZ_EDITOR_COMPONENT(GeoJSONSpawnerEditorComponent, GeoJSONSpawnerEditorComponentTypeId);
@@ -37,6 +40,9 @@ namespace GeoJSONSpawner
         void Activate() override;
         void Deactivate() override;
         void BuildGameEntity(AZ::Entity* gameEntity) override;
+
+        // AzFramework::Terrain::TerrainDataNotificationBus::Handler overrides
+        void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
 
     private:
         // EntityDebugDisplayEventBus::Handler overrides

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -46,7 +46,7 @@ namespace GeoJSONSpawner
         void BuildGameEntity(AZ::Entity* gameEntity) override;
 
         // AzFramework::Terrain::TerrainDataNotificationBus::Handler overrides
-        void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
+        void OnTerrainDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
 
     private:
         // EntityDebugDisplayEventBus::Handler overrides

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -12,6 +12,7 @@
 
 #include "GeoJSONSpawnerUtils.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
+#include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
 
 #include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
 
@@ -33,6 +34,9 @@ namespace GeoJSONSpawner
     {
     public:
         AZ_EDITOR_COMPONENT(GeoJSONSpawnerEditorComponent, GeoJSONSpawnerEditorComponentTypeId);
+
+        GeoJSONSpawnerEditorComponent() = default;
+        ~GeoJSONSpawnerEditorComponent() override = default;
 
         static void Reflect(AZ::ReflectContext* context);
 
@@ -60,6 +64,8 @@ namespace GeoJSONSpawner
 
         AZStd::vector<GeoJSONUtils::GeoJSONSpawnableEntityInfo> m_spawnableEntityInfo;
         AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_spawnedTicketsGroups;
+
+        GeoJSONSpawnerEditorTerrainSettingsConfig m_terrainSettingsConfig; //!< Terrain Editor Settings Configuration for GeoJSONSpawner
     };
 
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "GeoJSONSpawnerUtils.h"
 #include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h"
+#include "GeoJSONSpawnerUtils.h"
 
 #include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -9,10 +9,9 @@
  */
 
 #include "GeoJSONSpawnerUtils.h"
-
-#include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "Schemas/GeoJSONSchema.h"
 
+#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Math/Transform.h>
@@ -22,7 +21,6 @@
 #include <ROS2/Georeference/GeoreferenceBus.h>
 #include <random>
 #include <rapidjson/schema.h>
-
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -9,6 +9,8 @@
  */
 
 #include "GeoJSONSpawnerUtils.h"
+
+#include "AzFramework/Terrain/TerrainDataRequestBus.h"
 #include "Schemas/GeoJSONSchema.h"
 
 #include <AzCore/Asset/AssetSerializer.h>
@@ -569,4 +571,8 @@ namespace GeoJSONSpawner::GeoJSONUtils
         return GeometryType::Unknown;
     }
 
+    bool IsTerrainAvailable()
+    {
+        return AzFramework::Terrain::TerrainDataRequestBus::HasHandlers();
+    }
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -11,19 +11,19 @@
 #include "GeoJSONSpawnerUtils.h"
 #include "Schemas/GeoJSONSchema.h"
 
-#include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/Json/JsonUtils.h>
 #include <AzFramework/Components/TransformComponent.h>
-#include <ROS2/Georeference/GeoreferenceBus.h>
-#include <random>
-#include <rapidjson/schema.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzFramework/Terrain/TerrainDataRequestBus.h>
+#include <ROS2/Georeference/GeoreferenceBus.h>
+#include <random>
+#include <rapidjson/schema.h>
 
 namespace GeoJSONSpawner::GeoJSONUtils
 {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <GeoJSONSpawner/GeoJSONSpawnerTypeIds.h>
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -175,4 +175,8 @@ namespace GeoJSONSpawner::GeoJSONUtils
     //! @param geometryType - string with type of the geometry object
     //! @return enum connected with the given geometry type
     GeometryType GetGeometryType(const AZStd::string& geometryType);
+
+    //! This function checks if the Terrain is available in the level.
+    //! @returns True if level has any valid Terrain handlers, false otherwise.
+    [[nodiscard]] bool IsTerrainAvailable();
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/geojsonspawner_private_files.cmake
+++ b/Gems/GeoJSONSpawner/Code/geojsonspawner_private_files.cmake
@@ -9,4 +9,6 @@ set(FILES
     Source/GeoJSONSpawner/Schemas/GeoJSONSchema.h
     Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
     Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+    Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
+    Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
 )


### PR DESCRIPTION
## About:
The same changes as in #102.

Rely on built in Bus Notifies in `AzFramework::Terrain` to check if terrain is available in the level.
If available - use `OnTerrainUpdated()` in Editor Component and `OnTerrainCreateEnd()` for Game Component.

It adds the same features for editor:
- to enable / disable spawning on activation
- enable / disable spawning on terrain update
- what terrain masks will be ignored when terrain update is called

## Merging Order
[`wc/geo_json_terrain_support`](#104) -> [`wc/terrain_notify_update`](#102) -> [`main`](https://github.com/RobotecAI/robotec-o3de-tools/tree/main)
