### PR TITLE
Fixed typo in the error log

### DIFF
--- a/Gems/Pointcloud/Code/Source/Render/PointcloudFeatureProcessor.cpp
+++ b/Gems/Pointcloud/Code/Source/Render/PointcloudFeatureProcessor.cpp
@@ -35,7 +35,7 @@ namespace Pointcloud
 
         if (!m_shader)
         {
-            AZ_Error("PointcloudFeatureProcessor", false, "Failed to load required stars shader.");
+            AZ_Error("PointcloudFeatureProcessor", false, "Failed to load required pointcloud shader.");
             return;
         }
         AZ::Data::AssetBus::MultiHandler::BusConnect(m_shader->GetAssetId());


### PR DESCRIPTION
As in the title, fixed a typo that probably occurred when adapting the Stars Gem source code to use it as a point cloud visualiser.