### PR TITLE
Added setreg option to enable/disable centering mouse cursor in RobotecSpectatorCamera

### DIFF
--- a/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
+++ b/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
@@ -10,7 +10,7 @@
 
 namespace RobotecSpectatorCamera
 {
-    constexpr AZStd::string_view CenterTheCursorConfigurationKey = "/O3DE/Camera/MoveCursorToTheCenter";
+    constexpr AZStd::string_view CenterTheCursorConfigurationKey = "/O3DE/SpectatorCamera/MoveCursorToTheCenter";
 
     SpectatorCameraComponent::SpectatorCameraComponent(
         const RobotecSpectatorCamera::SpectatorCameraConfiguration& spectatorCameraConfiguration)

--- a/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.h
+++ b/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.h
@@ -62,7 +62,8 @@ namespace RobotecSpectatorCamera
         float m_yaw{ 0.0f };
         bool m_isRightMouseButtonPressed{ false };
         bool m_ignoreNextMovement{ false };
-        AZ::Vector2 m_initialMousePosition;
+        bool m_centerTheCursor{ false };
+        AZ::Vector2 m_initialMousePosition{ AZ::Vector2::CreateZero() };
         AZ::Vector2 m_lastMousePosition{ AZ::Vector2::CreateZero() };
         AZ::Vector3 m_movement{ AZ::Vector3::CreateZero() };
         AZ::Vector2 m_rotation{ AZ::Vector2::CreateZero() };


### PR DESCRIPTION
As the title suggests, this PR introduces the passing of the new setreg boolean variable `/O3DE/Camera/MoveCursorToTheCenter`. This variable indicates whether the cursor should be moved to the center of the window when the mouse is moved, or whether the cursor should follow the mouse around the screen (as it normally does).