### PR TITLE
Changed path passed to game component to relative path

### DIFF
--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerEditorComponent.cpp
@@ -182,7 +182,7 @@ namespace GeoJSONSpawner
         const auto featureObjectInfo = GeoJSONUtils::ParseJSONFromFile(sourcePath.c_str());
         auto spawnableEntitiesInfo =
             GeoJSONUtils::GetSpawnableEntitiesFromFeatureObjectVector(featureObjectInfo, spawnableAssetConfigurationsMap);
-        gameEntity->CreateComponent<GeoJSONSpawnerComponent>(spawnableAssetConfigurationsMap, sourcePath.c_str(), m_defaultSeed);
+        gameEntity->CreateComponent<GeoJSONSpawnerComponent>(spawnableAssetConfigurationsMap, sourceAssetInfo.m_relativePath.c_str(), m_defaultSeed);
         m_spawnedTicketsGroups.clear();
     }
 


### PR DESCRIPTION
Changed the path passed from GeoJSONSpawnerEditorComponent to GeoJSONSpawnerComponent from an absolute path to a relative path. This is a fix for a case where GeoJSON is part of the binary built using the export-project script - in such a situation GeoJSONSpawnerComponent tried to look for an absolute path, which could lead to an error on other machines.