### PR TITLE
Added nullptr check in the ViewportStreamerSystemComponent

### DIFF
--- a/Gems/ViewportStreamer/Code/Source/Clients/ViewportStreamerSystemComponent.cpp
+++ b/Gems/ViewportStreamer/Code/Source/Clients/ViewportStreamerSystemComponent.cpp
@@ -190,7 +190,10 @@ namespace ViewportStreamer
             }
 
             auto imageMessage = CreateImageMessageFromReadBackResult(GetEntityId(), result, header);
-            m_imagePublisher->publish(imageMessage);
+            if (m_imagePublisher)
+            {
+                m_imagePublisher->publish(imageMessage);
+            }
         };
         RequestFrame(passHierarchy, imageReadyCallback);
     }


### PR DESCRIPTION
Added check if `m_imagePublisher` is a nullptr before calling the `publish` method.
ViewportStreamer crashes o3de editor if opened level is quite small and empty (e.g. DefaultLevel) (probably the same behaviour could be observed if the machine the simulation is running on is powerful enough to do a quick exit from game mode) - Segmentation fault occurs after exiting game mode because m_imagePublisher pointer is already cleared and set to `nullptr` when there are still queued requests to the `RequestMessagePublication` function.