### PR TITLE
GeoJSONSpawner - Notification Bus

### DIFF
--- a/Gems/GeoJSONSpawner/Code/CMakeLists.txt
+++ b/Gems/GeoJSONSpawner/Code/CMakeLists.txt
@@ -27,6 +27,7 @@ ly_add_target(
     INCLUDE_DIRECTORIES
         INTERFACE
             Include
+            Source
     BUILD_DEPENDENCIES
         INTERFACE
            AZ::AzCore

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -30,6 +30,7 @@ namespace GeoJSONSpawner
     class GeoJSONSpawnerRequests : public AZ::ComponentBus
     {
     public:
+        AZ_RTTI(GeoJSONSpawnerRequests, GeoJSONSpawnerRequestsTypeId);
         using BusIdType = AZ::EntityId;
         using MutexType = AZStd::mutex;
 

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -72,7 +72,7 @@ namespace GeoJSONSpawner
     class GeoJSONSpawnerInterface : public AZ::EBusTraits
     {
     public:
-        AZ_RTTI(GeoJSONSpawnerInterface, GeoJSONSpawnerNotificationsTypeId);
+        AZ_RTTI(GeoJSONSpawnerInterface, GeoJSONSpawnerInterfaceTypeId);
         virtual ~GeoJSONSpawnerInterface() = default;
 
         /**

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -87,13 +87,13 @@ namespace GeoJSONSpawner
          * @brief Called when entity spawning finishes.
          *
          * @param spawnedEntityTickets A map linking an integer ID to a list of spawned entity tickets.
-         * @param m_statusCode Status code indicating success, failure, or warnings.
+         * @param m_statusFlag Status code indicating success, failure, or warnings.
          *
          * This function is triggered when all entities in a spawn operation are processed.
          */
         virtual void OnEntitiesSpawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
-            GeoJSONUtils::SpawnStatus m_statusCode) = 0;
+            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
 
         /**
          * @brief Called when entity despawning begins.
@@ -106,13 +106,13 @@ namespace GeoJSONSpawner
          * @brief Called when entity despawning finishes.
          *
          * @param despawnedEntityTickets A map linking an integer ID to a list of despawned entity tickets.
-         * @param m_statusCode Status code indicating success, failure, or warnings.
+         * @param m_statusFlag Status code indicating success, failure, or warnings.
          *
          * This function is triggered when all entities in a despawn operation are processed.
          */
         virtual void OnEntitiesDespawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
-            GeoJSONUtils::SpawnStatus m_statusCode) = 0;
+            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
 
         /**
          * @brief Called when an individual entity is successfully spawned.
@@ -161,9 +161,9 @@ namespace GeoJSONSpawner
 
         void OnEntitiesSpawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
-            GeoJSONUtils::SpawnStatus m_statusCode) override
+            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
         {
-            Call(FN_OnEntitiesSpawnFinished, spawnedEntityTickets, m_statusCode);
+            Call(FN_OnEntitiesSpawnFinished, spawnedEntityTickets, m_statusFlag);
         }
 
         void OnEntitiesDespawnBegin() override
@@ -173,9 +173,9 @@ namespace GeoJSONSpawner
 
         void OnEntitiesDespawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
-            GeoJSONUtils::SpawnStatus m_statusCode) override
+            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
         {
-            Call(FN_OnEntitiesDespawnFinished, despawnedEntityTickets, m_statusCode);
+            Call(FN_OnEntitiesDespawnFinished, despawnedEntityTickets, m_statusFlag);
         }
 
         void OnEntitySpawn(AzFramework::EntitySpawnTicket& spawnedEntityTicket) override

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -10,7 +10,11 @@
 
 #pragma once
 
+#include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/IO/Path/Path_fwd.h>
+#include <AzCore/Outcome/Outcome.h>
+#include <AzCore/std/string/string.h>
 
 namespace GeoJSONSpawner
 {

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -17,8 +17,8 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/IO/Path/Path_fwd.h>
 #include <AzCore/Outcome/Outcome.h>
-#include <AzCore/std/string/string.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/string/string.h>
 
 namespace GeoJSONSpawner
 {
@@ -64,11 +64,11 @@ namespace GeoJSONSpawner
     using GeoJSONSpawnerRequestBus = AZ::EBus<GeoJSONSpawnerRequests>;
 
     /**
-    * @brief Interface for handling entity spawn events for GeoJSON Spawner.
-    *
-    * GeoJSONSpawnerInterface is an Event Bus interface that notifies multiple
-    * listeners when entity spawning begins and finishes.
-    */
+     * @brief Interface for handling entity spawn events for GeoJSON Spawner.
+     *
+     * GeoJSONSpawnerInterface is an Event Bus interface that notifies multiple
+     * listeners when entity spawning begins and finishes.
+     */
     class GeoJSONSpawnerInterface : public AZ::EBusTraits
     {
     public:
@@ -77,24 +77,27 @@ namespace GeoJSONSpawner
 
         /**
          * @brief Called when entity spawning begins.
-         * @param m_spawnInfo Struct holding information about entities to be spawned.
          */
-        virtual void OnEntitiesSpawnBegin(GeoJSONUtils::SpawnInfo& m_spawnInfo) = 0;
+        virtual void OnEntitiesSpawnBegin() = 0;
 
         /**
          * @brief Called when entity spawning finishes.
-         * @param m_spawnInfo Struct holding information about entities to be spawned.
+         * @param spawnedEntityTickets Map of int and vector of entity spawn tickets.
          * @param m_statusCode Status code indicating success, failure and warnings of the spawn.
          */
-        virtual void OnEntitiesSpawnFinished(GeoJSONUtils::SpawnInfo& m_spawnInfo, GeoJSONUtils::SpawnStatus m_statusCode) = 0;
+        virtual void OnEntitiesSpawnFinished(
+            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
+            GeoJSONUtils::SpawnStatus m_statusCode) = 0;
 
         virtual void OnEntitiesDespawnBegin() = 0;
 
-        virtual void OnEntiteisDespawnFinished() = 0;
+        virtual void OnEntitiesDespawnFinished(
+            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
+            GeoJSONUtils::SpawnStatus m_statusCode) = 0;
 
-        virtual void OnEntitySpawn() = 0;
+        virtual void OnEntitySpawn(AzFramework::EntitySpawnTicket& spawnedEntityTicket) = 0;
 
-        virtual void OnEntityDespawn() = 0;
+        virtual void OnEntityDespawn(AzFramework::EntitySpawnTicket& despawnedEntityTicket) = 0;
 
         /// EBus Configuration - Allows multiple listeners to handle events.
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
@@ -114,18 +117,20 @@ namespace GeoJSONSpawner
             OnEntitiesSpawnBegin,
             OnEntitiesSpawnFinished,
             OnEntitiesDespawnBegin,
-            OnEntiteisDespawnFinished,
+            OnEntitiesDespawnFinished,
             OnEntitySpawn,
             OnEntityDespawn);
 
-        void OnEntitiesSpawnBegin(GeoJSONUtils::SpawnInfo& m_spawnInfo) override
+        void OnEntitiesSpawnBegin() override
         {
-            Call(FN_OnEntitiesSpawnBegin, m_spawnInfo);
+            Call(FN_OnEntitiesSpawnBegin);
         }
 
-        void OnEntitiesSpawnFinished(GeoJSONUtils::SpawnInfo& m_spawnInfo, GeoJSONUtils::SpawnStatus m_statusCode) override
+        void OnEntitiesSpawnFinished(
+            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
+            GeoJSONUtils::SpawnStatus m_statusCode) override
         {
-            Call(FN_OnEntitiesSpawnFinished, m_spawnInfo, m_statusCode);
+            Call(FN_OnEntitiesSpawnFinished, spawnedEntityTickets, m_statusCode);
         }
 
         void OnEntitiesDespawnBegin() override
@@ -133,14 +138,21 @@ namespace GeoJSONSpawner
             Call(FN_OnEntitiesDespawnBegin);
         }
 
-        void OnEntiteisDespawnFinished() override
+        void OnEntitiesDespawnFinished(
+            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
+            GeoJSONUtils::SpawnStatus m_statusCode) override
         {
-            Call(FN_OnEntiteisDespawnFinished);
+            Call(FN_OnEntitiesDespawnFinished, despawnedEntityTickets, m_statusCode);
         }
 
-        void OnEntityDespawn() override
+        void OnEntitySpawn(AzFramework::EntitySpawnTicket& spawnedEntityTicket) override
         {
-            Call(FN_OnEntityDespawn);
+            Call(FN_OnEntitySpawn, spawnedEntityTicket);
+        }
+
+        void OnEntityDespawn(AzFramework::EntitySpawnTicket& despawnedEntityTicket) override
+        {
+            Call(FN_OnEntityDespawn, despawnedEntityTicket);
         }
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -88,6 +88,14 @@ namespace GeoJSONSpawner
          */
         virtual void OnEntitiesSpawnFinished(GeoJSONUtils::SpawnInfo& m_spawnInfo, GeoJSONUtils::SpawnStatus m_statusCode) = 0;
 
+        virtual void OnEntitiesDespawnBegin() = 0;
+
+        virtual void OnEntiteisDespawnFinished() = 0;
+
+        virtual void OnEntitySpawn() = 0;
+
+        virtual void OnEntityDespawn() = 0;
+
         /// EBus Configuration - Allows multiple listeners to handle events.
         static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
     };
@@ -104,7 +112,11 @@ namespace GeoJSONSpawner
             GeoJSONSpawnerNotificationBusHandlerTypeId,
             AZ::SystemAllocator,
             OnEntitiesSpawnBegin,
-            OnEntitiesSpawnFinished);
+            OnEntitiesSpawnFinished,
+            OnEntitiesDespawnBegin,
+            OnEntiteisDespawnFinished,
+            OnEntitySpawn,
+            OnEntityDespawn);
 
         void OnEntitiesSpawnBegin(GeoJSONUtils::SpawnInfo& m_spawnInfo) override
         {
@@ -114,6 +126,21 @@ namespace GeoJSONSpawner
         void OnEntitiesSpawnFinished(GeoJSONUtils::SpawnInfo& m_spawnInfo, GeoJSONUtils::SpawnStatus m_statusCode) override
         {
             Call(FN_OnEntitiesSpawnFinished, m_spawnInfo, m_statusCode);
+        }
+
+        void OnEntitiesDespawnBegin() override
+        {
+            Call(FN_OnEntitiesDespawnBegin);
+        }
+
+        void OnEntiteisDespawnFinished() override
+        {
+            Call(FN_OnEntiteisDespawnFinished);
+        }
+
+        void OnEntityDespawn() override
+        {
+            Call(FN_OnEntityDespawn);
         }
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -10,8 +10,9 @@
 
 #pragma once
 
+#include "GeoJSONSpawner/GeoJSONSpawnerUtils.h"
+#include "GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.h"
 #include "GeoJSONSpawnerTypeIds.h"
-#include <GeoJSONSpawner/GeoJSONSpawnerUtils.h>
 
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
@@ -92,8 +93,7 @@ namespace GeoJSONSpawner
          * This function is triggered when all entities in a spawn operation are processed.
          */
         virtual void OnEntitiesSpawnFinished(
-            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
-            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
+            GeoJSONWrappers::SpawnTicketMapWrapper& spawnedEntityTickets, GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
 
         /**
          * @brief Called when entity despawning begins.
@@ -111,8 +111,7 @@ namespace GeoJSONSpawner
          * This function is triggered when all entities in a despawn operation are processed.
          */
         virtual void OnEntitiesDespawnFinished(
-            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
-            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
+            GeoJSONWrappers::SpawnTicketMapWrapper& despawnedEntityTickets, GeoJSONUtils::SpawnDespawnStatus m_statusFlag) = 0;
 
         /**
          * @brief Called when an individual entity is successfully spawned.
@@ -160,8 +159,7 @@ namespace GeoJSONSpawner
         }
 
         void OnEntitiesSpawnFinished(
-            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
-            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
+            GeoJSONWrappers::SpawnTicketMapWrapper& spawnedEntityTickets, GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
         {
             Call(FN_OnEntitiesSpawnFinished, spawnedEntityTickets, m_statusFlag);
         }
@@ -172,8 +170,7 @@ namespace GeoJSONSpawner
         }
 
         void OnEntitiesDespawnFinished(
-            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
-            GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
+            GeoJSONWrappers::SpawnTicketMapWrapper& despawnedEntityTickets, GeoJSONUtils::SpawnDespawnStatus m_statusFlag) override
         {
             Call(FN_OnEntitiesDespawnFinished, despawnedEntityTickets, m_statusFlag);
         }

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerBus.h
@@ -64,10 +64,10 @@ namespace GeoJSONSpawner
     using GeoJSONSpawnerRequestBus = AZ::EBus<GeoJSONSpawnerRequests>;
 
     /**
-     * @brief Interface for handling entity spawn events for GeoJSON Spawner.
+     * @brief Interface for handling entity spawn events in GeoJSON Spawner.
      *
-     * GeoJSONSpawnerInterface is an Event Bus interface that notifies multiple
-     * listeners when entity spawning begins and finishes.
+     * GeoJSONSpawnerInterface is an Event Bus (EBus) interface that notifies multiple listeners
+     * when entity spawning and despawning begins or finishes.
      */
     class GeoJSONSpawnerInterface : public AZ::EBusTraits
     {
@@ -77,26 +77,58 @@ namespace GeoJSONSpawner
 
         /**
          * @brief Called when entity spawning begins.
+         *
+         * Notifies multiple listeners that a batch entity spawning process has started.
          */
         virtual void OnEntitiesSpawnBegin() = 0;
 
         /**
          * @brief Called when entity spawning finishes.
-         * @param spawnedEntityTickets Map of int and vector of entity spawn tickets.
-         * @param m_statusCode Status code indicating success, failure and warnings of the spawn.
+         *
+         * @param spawnedEntityTickets A map linking an integer ID to a list of spawned entity tickets.
+         * @param m_statusCode Status code indicating success, failure, or warnings.
+         *
+         * This function is triggered when all entities in a spawn operation are processed.
          */
         virtual void OnEntitiesSpawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& spawnedEntityTickets,
             GeoJSONUtils::SpawnStatus m_statusCode) = 0;
 
+        /**
+         * @brief Called when entity despawning begins.
+         *
+         * Notifies multiple listeners that a batch entity despawning process has started.
+         */
         virtual void OnEntitiesDespawnBegin() = 0;
 
+        /**
+         * @brief Called when entity despawning finishes.
+         *
+         * @param despawnedEntityTickets A map linking an integer ID to a list of despawned entity tickets.
+         * @param m_statusCode Status code indicating success, failure, or warnings.
+         *
+         * This function is triggered when all entities in a despawn operation are processed.
+         */
         virtual void OnEntitiesDespawnFinished(
             AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& despawnedEntityTickets,
             GeoJSONUtils::SpawnStatus m_statusCode) = 0;
 
+        /**
+         * @brief Called when an individual entity is successfully spawned.
+         *
+         * @param spawnedEntityTicket The spawn ticket representing the successfully spawned entity.
+         *
+         * This function is triggered per entity when it spawns.
+         */
         virtual void OnEntitySpawn(AzFramework::EntitySpawnTicket& spawnedEntityTicket) = 0;
 
+        /**
+         * @brief Called when an individual entity is successfully despawned.
+         *
+         * @param despawnedEntityTicket The spawn ticket representing the successfully despawned entity.
+         *
+         * This function is triggered per entity when it despawns.
+         */
         virtual void OnEntityDespawn(AzFramework::EntitySpawnTicket& despawnedEntityTicket) = 0;
 
         /// EBus Configuration - Allows multiple listeners to handle events.

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -38,6 +38,6 @@ namespace GeoJSONSpawner
 
     // Interface TypeIds
     inline constexpr const char* GeoJSONSpawnerRequestsTypeId = "{EE523E9E-CFDF-4590-BBDE-054848BBA790}";
-    inline constexpr const char* GeoJSONSpawnerNotificationsTypeId = "{4770B38A-D018-4184-A672-3F9155B7BEE7}";
+    inline constexpr const char* GeoJSONSpawnerInterfaceTypeId = "{4770B38A-D018-4184-A672-3F9155B7BEE7}";
     inline constexpr const char* GeoJSONSpawnerNotificationBusHandlerTypeId = "{9D8C5E99-7151-4AA4-9B5F-2D8AE2F097F7}";
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -31,7 +31,6 @@ namespace GeoJSONSpawner
     inline constexpr const char* GeoJSONSpawnableEntityInfoTypeId = "{170bb487-fbae-4394-8176-069045a3a316}";
     inline constexpr const char* FeatureObjectInfoTypeId = "{00f38302-9f4d-4bac-805b-72a29e42a704}";
     inline constexpr const char* GeoJSONSpawnerEditorTerrainSettingsConfigTypeId = "{9bb9e1c6-dd7c-435f-8fe1-bd5498c3e8f2}";
-    inline constexpr const char* GeoJSONSpawnerSpawnInfoTypeId = "{A3A7A29F-C3A6-4B7E-8169-24F052B92FAD}";
 
     // Components TypeIds
     inline constexpr const char* GeoJSONSpawnerComponentTypeId = "{839ede69-92f1-45b0-a60e-035d0b84e1fd}";

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -31,10 +31,13 @@ namespace GeoJSONSpawner
     inline constexpr const char* GeoJSONSpawnableEntityInfoTypeId = "{170bb487-fbae-4394-8176-069045a3a316}";
     inline constexpr const char* FeatureObjectInfoTypeId = "{00f38302-9f4d-4bac-805b-72a29e42a704}";
     inline constexpr const char* GeoJSONSpawnerEditorTerrainSettingsConfigTypeId = "{9bb9e1c6-dd7c-435f-8fe1-bd5498c3e8f2}";
+    inline constexpr const char* GeoJSONSpawnerSpawnInfoTypeId = "{A3A7A29F-C3A6-4B7E-8169-24F052B92FAD}";
 
     // Components TypeIds
     inline constexpr const char* GeoJSONSpawnerComponentTypeId = "{839ede69-92f1-45b0-a60e-035d0b84e1fd}";
 
     // Interface TypeIds
     inline constexpr const char* GeoJSONSpawnerRequestsTypeId = "{EE523E9E-CFDF-4590-BBDE-054848BBA790}";
+    inline constexpr const char* GeoJSONSpawnerNotificationsTypeId = "{4770B38A-D018-4184-A672-3F9155B7BEE7}";
+    inline constexpr const char* GeoJSONSpawnerNotificationBusHandlerTypeId = "{9D8C5E99-7151-4AA4-9B5F-2D8AE2F097F7}";
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -32,6 +32,9 @@ namespace GeoJSONSpawner
     inline constexpr const char* FeatureObjectInfoTypeId = "{00f38302-9f4d-4bac-805b-72a29e42a704}";
     inline constexpr const char* GeoJSONSpawnerEditorTerrainSettingsConfigTypeId = "{9bb9e1c6-dd7c-435f-8fe1-bd5498c3e8f2}";
 
+    // Wrapper TypeIds
+    inline constexpr const char* GeoJSONSpawnerSpawnTicketMapWrapperTypeId = "{714316F3-190D-4189-B14B-B601BE22EEBC}";
+
     // Components TypeIds
     inline constexpr const char* GeoJSONSpawnerComponentTypeId = "{839ede69-92f1-45b0-a60e-035d0b84e1fd}";
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -168,6 +168,9 @@ namespace GeoJSONSpawner
         {
             m_spawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Warning | GeoJSONUtils::SpawnDespawnStatus::Invalid;
         }
+
+        // Copy Spawn Tickets for notification bus
+        m_copySpawnTickets.SetMap(m_spawnableTickets);
     }
 
     void GeoJSONSpawnerComponent::SpawnCachedEntities(const AZStd::vector<GeoJSONUtils::FeatureObjectInfo>& cachedObjectsToSpawn)

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -365,6 +365,9 @@ namespace GeoJSONSpawner
 
     void GeoJSONSpawnerComponent::DespawnAllEntities()
     {
+        // Call GeoJSONSpawner EBus notification - Despawn Begin
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesDespawnBegin);
+
         FillGroupIdToTicketIdMap();
 
         for (auto& pair : m_spawnableTickets)
@@ -374,10 +377,16 @@ namespace GeoJSONSpawner
                 Despawn(ticket);
             }
         }
+
+        // Call GeoJSONSpawner EBus notification - Despawn Finished
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntiteisDespawnFinished);
     }
 
     void GeoJSONSpawnerComponent::DespawnEntitiesById(const GeoJSONUtils::Ids& ids)
     {
+        // Call GeoJSONSpawner EBus notification - Despawn Begin
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesDespawnBegin);
+
         FillGroupIdToTicketIdMap(ids);
 
         for (const auto idToDespawn : ids)
@@ -394,6 +403,9 @@ namespace GeoJSONSpawner
                 Despawn(ticket);
             }
         }
+
+        // Call GeoJSONSpawner EBus notification - Despawn Finished
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntiteisDespawnFinished);
     }
 
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -166,7 +166,7 @@ namespace GeoJSONSpawner
 
         if (m_spawnableTickets.empty())
         {
-            m_spawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Invalid | GeoJSONUtils::SpawnDespawnStatus::Invalid;
+            m_spawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Warning | GeoJSONUtils::SpawnDespawnStatus::Invalid;
         }
     }
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -78,10 +78,12 @@ namespace GeoJSONSpawner
         if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Success)>("SpawnStatus_Success");
-            ;
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Fail)>("SpawnStatus_Fail");
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Stopped)>("SpawnStatus_Stopped");
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Warning)>("SpawnStatus_Warning");
+
+            behaviorContext->EBus<GeoJSONSpawner::GeoJSONSpawnerNotificationBus>("GeoJSONSpawnerNotificationBus")
+                ->Handler<GeoJSONSpawner::GeoJSONSpawnerNotificationBusHandler>();
         }
     }
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -10,6 +10,8 @@
 
 #include "GeoJSONSpawnerComponent.h"
 
+#include "Wrappers/SpawnTicketMapWrapper.h"
+
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Components/TransformComponent.h>
@@ -58,6 +60,7 @@ namespace GeoJSONSpawner
         GeoJSONUtils::GeoJSONSpawnableAssetConfiguration::Reflect(context);
         GeoJSONUtils::GeoJSONSpawnableEntityInfo::Reflect(context);
         GeoJSONUtils::FeatureObjectInfo::Reflect(context);
+        GeoJSONWrappers::SpawnTicketMapWrapper::Reflect(context);
 
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
@@ -196,7 +199,7 @@ namespace GeoJSONSpawner
         }
 
         // Copy Spawn Tickets for notification bus
-        m_copySpawnTickets = m_spawnableTickets;
+        m_copySpawnTickets.SetMap(m_spawnableTickets);
     }
 
     Result GeoJSONSpawnerComponent::SpawnWithRawString(const AZStd::string& rawJsonString)
@@ -421,7 +424,7 @@ namespace GeoJSONSpawner
         ResetSpawnDespawnStatus(m_despawnStatus, m_copyDespawnTickets);
 
         // Copy Spawn Tickets for notification bus
-        m_copyDespawnTickets = m_spawnableTickets;
+        m_copyDespawnTickets.SetMap(m_spawnableTickets);
 
         FillGroupIdToTicketIdMap();
 
@@ -461,7 +464,7 @@ namespace GeoJSONSpawner
             }
 
             // Copy Spawn Tickets for notification bus
-            m_copyDespawnTickets[idToDespawn] = it->second;
+            m_copyDespawnTickets.SetValues(idToDespawn, it->second);
 
             for (auto& ticket : m_spawnableTickets[idToDespawn])
             {
@@ -470,17 +473,17 @@ namespace GeoJSONSpawner
         }
 
         // Notify - Copied tickets cannot be empty
-        if (m_copyDespawnTickets.empty())
+        if (m_copyDespawnTickets.GetMap().empty())
         {
             m_despawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Invalid | GeoJSONUtils::SpawnDespawnStatus::Fail;
         }
     }
 
     void GeoJSONSpawnerComponent::ResetSpawnDespawnStatus(
-        GeoJSONUtils::SpawnDespawnStatus& status, AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& mapCopy) const
+        GeoJSONUtils::SpawnDespawnStatus& status, GeoJSONWrappers::SpawnTicketMapWrapper& mapCopy)
     {
-        mapCopy.clear();
-
         status = m_spawnableTickets.empty() ? GeoJSONUtils::SpawnDespawnStatus::Fail : GeoJSONUtils::SpawnDespawnStatus::Success;
+        mapCopy.Clear();
     }
+
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -66,7 +66,8 @@ namespace GeoJSONSpawner
                 ->Value("Success", GeoJSONUtils::SpawnStatus::Success)
                 ->Value("Fail", GeoJSONUtils::SpawnStatus::Fail)
                 ->Value("Stopped", GeoJSONUtils::SpawnStatus::Stopped)
-                ->Value("Warning", GeoJSONUtils::SpawnStatus::Warning);
+                ->Value("Warning", GeoJSONUtils::SpawnStatus::Warning)
+                ->Value("Invalid", GeoJSONUtils::SpawnStatus::Invalid);
 
             serializeContext->Class<GeoJSONSpawnerComponent, AZ::Component>()
                 ->Version(0)
@@ -81,6 +82,7 @@ namespace GeoJSONSpawner
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Fail)>("SpawnStatus_Fail");
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Stopped)>("SpawnStatus_Stopped");
             behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Warning)>("SpawnStatus_Warning");
+            behaviorContext->EnumProperty<static_cast<int>(GeoJSONUtils::SpawnStatus::Invalid)>("SpawnStatus_Invalid");
 
             behaviorContext->EBus<GeoJSONSpawner::GeoJSONSpawnerNotificationBus>("GeoJSONSpawnerNotificationBus")
                 ->Handler<GeoJSONSpawner::GeoJSONSpawnerNotificationBusHandler>();

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -181,6 +181,8 @@ namespace GeoJSONSpawner
     {
         if (m_spawnerState != SpawnerState::Idle || !m_spawnerStateQueue.empty())
         {
+            m_spawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Fail | GeoJSONUtils::SpawnDespawnStatus::Invalid |
+                GeoJSONUtils::SpawnDespawnStatus::Stopped;
             return AZ::Failure(AZStd::string("Spawner is handling previous request. Action aborted."));
         }
 
@@ -366,7 +368,8 @@ namespace GeoJSONSpawner
     {
         if (!ticketToDespawn.IsValid())
         {
-            m_despawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Warning;
+            m_despawnStatus |= GeoJSONUtils::SpawnDespawnStatus::Warning | GeoJSONUtils::SpawnDespawnStatus::Invalid |
+                GeoJSONUtils::SpawnDespawnStatus::Stopped | GeoJSONUtils::SpawnDespawnStatus::Fail;
             return;
         }
 
@@ -441,7 +444,7 @@ namespace GeoJSONSpawner
                 continue;
             }
 
-            copyOfTickets[idToDespawn] = it->second; // Copy before modification
+            copyOfTickets[idToDespawn] = it->second; // Copy
 
             for (auto& ticket : m_spawnableTickets[idToDespawn])
             {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.cpp
@@ -381,7 +381,6 @@ namespace GeoJSONSpawner
                     if (pair.second.empty())
                     {
                         m_spawnableTickets.erase(pair.first);
-                        m_despawnStatus |= GeoJSONUtils::SpawnStatus::Warning;
                     }
                 }
                 m_ticketsToDespawn--;

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -92,12 +92,16 @@ namespace GeoJSONSpawner
         AZStd::atomic<unsigned int> m_ticketsToDespawn{ 0 };
         AZStd::atomic<unsigned int> m_ticketsToSpawn{ 0 };
         AZStd::vector<GeoJSONUtils::GeoJSONSpawnableEntityInfo> m_spawnableEntityInfo;
-        GeoJSONUtils::SpawnStatus m_despawnStatus = GeoJSONUtils::SpawnStatus::Success;
 
         SpawnerState m_spawnerState{ SpawnerState::Idle };
         AZStd::queue<SpawnerState> m_spawnerStateQueue;
 
         // Terrain notify
         bool m_terrainCreatedOnlyOnce{ false }; //!< Is terrain fully generated once
+
+        // Spawn & Despawn notify
+        GeoJSONUtils::SpawnDespawnStatus m_spawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
+        GeoJSONUtils::SpawnDespawnStatus m_despawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
+        [[nodiscard]] GeoJSONUtils::SpawnDespawnStatus InitSpawnDespawnStatus() const;
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -106,6 +106,8 @@ namespace GeoJSONSpawner
         GeoJSONUtils::SpawnDespawnStatus m_despawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
         AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_copyDespawnTickets;
 
-        [[nodiscard]] GeoJSONUtils::SpawnDespawnStatus ResetSpawnDespawnStatus();
+        void ResetSpawnDespawnStatus(
+            GeoJSONUtils::SpawnDespawnStatus& status,
+            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& mapCopy) const;
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
+#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 #include "GeoJSONSpawnerUtils.h"
-#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -101,13 +101,11 @@ namespace GeoJSONSpawner
 
         // Spawn & Despawn notify
         GeoJSONUtils::SpawnDespawnStatus m_spawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
-        AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_copySpawnTickets;
+        GeoJSONWrappers::SpawnTicketMapWrapper m_copySpawnTickets;
 
         GeoJSONUtils::SpawnDespawnStatus m_despawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
-        AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_copyDespawnTickets;
+        GeoJSONWrappers::SpawnTicketMapWrapper m_copyDespawnTickets;
 
-        void ResetSpawnDespawnStatus(
-            GeoJSONUtils::SpawnDespawnStatus& status,
-            AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& mapCopy) const;
+        void ResetSpawnDespawnStatus(GeoJSONUtils::SpawnDespawnStatus& status, GeoJSONWrappers::SpawnTicketMapWrapper& mapCopy);
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -101,7 +101,11 @@ namespace GeoJSONSpawner
 
         // Spawn & Despawn notify
         GeoJSONUtils::SpawnDespawnStatus m_spawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
+        AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_copySpawnTickets;
+
         GeoJSONUtils::SpawnDespawnStatus m_despawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
-        [[nodiscard]] GeoJSONUtils::SpawnDespawnStatus InitSpawnDespawnStatus() const;
+        AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_copyDespawnTickets;
+
+        [[nodiscard]] GeoJSONUtils::SpawnDespawnStatus ResetSpawnDespawnStatus();
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -10,9 +10,9 @@
 
 #pragma once
 
-#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 #include "GeoJSONSpawnerUtils.h"
+#include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -82,6 +82,9 @@ namespace GeoJSONSpawner
         void DespawnEntitiesById(const GeoJSONUtils::Ids& ids);
         void Despawn(AzFramework::EntitySpawnTicket& ticketToDespawn);
 
+        // Spawn & Despawn
+        void ResetSpawnDespawnStatus(GeoJSONUtils::SpawnDespawnStatus& status, GeoJSONWrappers::SpawnTicketMapWrapper& mapCopy);
+
         AZStd::unordered_map<AZStd::string, GeoJSONUtils::GeoJSONSpawnableAssetConfiguration> m_spawnableAssetConfigurations;
         AZ::u64 m_defaultSeed;
         AZ::IO::Path m_geoJsonFilePath;
@@ -100,12 +103,10 @@ namespace GeoJSONSpawner
         bool m_terrainCreatedOnlyOnce{ false }; //!< Is terrain fully generated once
 
         // Spawn & Despawn notify
-        GeoJSONUtils::SpawnDespawnStatus m_spawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
+        GeoJSONUtils::SpawnDespawnStatus m_spawnStatus{ GeoJSONUtils::SpawnDespawnStatus::Success };
         GeoJSONWrappers::SpawnTicketMapWrapper m_copySpawnTickets;
 
-        GeoJSONUtils::SpawnDespawnStatus m_despawnStatus = GeoJSONUtils::SpawnDespawnStatus::Success;
+        GeoJSONUtils::SpawnDespawnStatus m_despawnStatus{ GeoJSONUtils::SpawnDespawnStatus::Success };
         GeoJSONWrappers::SpawnTicketMapWrapper m_copyDespawnTickets;
-
-        void ResetSpawnDespawnStatus(GeoJSONUtils::SpawnDespawnStatus& status, GeoJSONWrappers::SpawnTicketMapWrapper& mapCopy);
     };
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -58,7 +58,7 @@ namespace GeoJSONSpawner
         Result Modify(const AZStd::string& rawJsonString) override;
         Result DeleteAll() override;
         Result DeleteById(const AZStd::unordered_set<int>& idsToDelete) override;
-        GetIdsResult GetIds() const override;
+        [[nodiscard]] GetIdsResult GetIds() const override;
 
         // AzFramework::Terrain::TerrainDataNotificationBus overrides
         void OnTerrainDataCreateEnd() override;
@@ -75,7 +75,7 @@ namespace GeoJSONSpawner
         void FillGroupIdToTicketIdMap();
         void FillGroupIdToTicketIdMap(const AZStd::unordered_set<int>& groupIds);
 
-        unsigned int CountTicketsToSpawn(
+        [[nodiscard]] unsigned int CountTicketsToSpawn(
             const AZStd::unordered_map<int, AZStd::vector<GeoJSONUtils::TicketToSpawnPair>>& ticketsToSpawn) const;
 
         void DespawnAllEntities();

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -92,6 +92,7 @@ namespace GeoJSONSpawner
         AZStd::atomic<unsigned int> m_ticketsToDespawn{ 0 };
         AZStd::atomic<unsigned int> m_ticketsToSpawn{ 0 };
         AZStd::vector<GeoJSONUtils::GeoJSONSpawnableEntityInfo> m_spawnableEntityInfo;
+        GeoJSONUtils::SpawnStatus m_despawnStatus = GeoJSONUtils::SpawnStatus::Success;
 
         SpawnerState m_spawnerState{ SpawnerState::Idle };
         AZStd::queue<SpawnerState> m_spawnerStateQueue;

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerComponent.h
@@ -12,7 +12,7 @@
 
 #include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
 #include "GeoJSONSpawnerUtils.h"
-#include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
+#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -95,7 +95,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
                         AZ::Edit::UIHandlers::Default,
                         &GeoJSONSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on terrain",
-                        "Performance query raytrace to place spawnable on terrain.")
+                        "Perform scene query raytrace to place spawnable on terrain.")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &GeoJSONSpawnableAssetConfiguration::m_raytraceStartingHeight,

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -9,8 +9,8 @@
  */
 
 #include "GeoJSONSpawnerUtils.h"
-#include "Schemas/GeoJSONSchema.h"
 #include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
+#include "Schemas/GeoJSONSchema.h"
 
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/IO/FileIO.h>
@@ -260,14 +260,14 @@ namespace GeoJSONSpawner::GeoJSONUtils
     AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> SpawnEntities(
         AZStd::unordered_map<int, AZStd::vector<TicketToSpawnPair>>& ticketsToSpawn)
     {
-        // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
-        SpawnStatus spawnStatusCode = SpawnStatus::Success;
-
         // Call GeoJSONSpawner EBus notification - Begin
         GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnBegin);
 
         auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
         AZ_Assert(spawner, "Unable to get spawnable entities definition.");
+
+        // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
+        SpawnStatus spawnStatusCode = spawner ? SpawnStatus::Success : SpawnStatus::Fail;
 
         AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> groupIdToTicketsMap;
         for (auto& groupIdToSpawn : ticketsToSpawn)
@@ -288,8 +288,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
             }
         }
 
-        // Add notify code status
-        if (!spawner || groupIdToTicketsMap.empty())
+        if (groupIdToTicketsMap.empty())
         {
             spawnStatusCode |= SpawnStatus::Fail;
         }

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -275,8 +275,6 @@ namespace GeoJSONSpawner::GeoJSONUtils
             if (!groupIdToTicketsMap.contains(groupIdToSpawn.first))
             {
                 groupIdToTicketsMap[groupIdToSpawn.first] = {};
-                // Add notify code status
-                spawnStatusCode |= SpawnStatus::Warning;
             }
             for (auto& ticketToSpawn : groupIdToSpawn.second)
             {

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -95,7 +95,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
                         AZ::Edit::UIHandlers::Default,
                         &GeoJSONSpawnableAssetConfiguration::m_placeOnTerrain,
                         "Place on terrain",
-                        "Performscene query raytrace to place spawnable on terrain.")
+                        "Performance query raytrace to place spawnable on terrain.")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &GeoJSONSpawnableAssetConfiguration::m_raytraceStartingHeight,
@@ -310,6 +310,9 @@ namespace GeoJSONSpawner::GeoJSONUtils
             callback(id);
         };
         spawner->DespawnAllEntities(ticket, optionalArgs);
+
+        // Call GeoJSONSpawner EBus notification - Spawn
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntityDespawn);
     }
 
     AZStd::unordered_map<AZStd::string, GeoJSONSpawnableAssetConfiguration> GetSpawnableAssetFromVector(

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -260,9 +260,6 @@ namespace GeoJSONSpawner::GeoJSONUtils
     AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> SpawnEntities(
         AZStd::unordered_map<int, AZStd::vector<TicketToSpawnPair>>& ticketsToSpawn)
     {
-        // Call GeoJSONSpawner EBus notification - Begin
-        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnBegin);
-
         auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
         AZ_Assert(spawner, "Unable to get spawnable entities definition.");
 
@@ -291,9 +288,6 @@ namespace GeoJSONSpawner::GeoJSONUtils
             spawnStatusCode |= SpawnDespawnStatus::Fail;
         }
 
-        // Call GeoJSONSpawner EBus notification - Finished
-        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnFinished, groupIdToTicketsMap, spawnStatusCode);
-
         return groupIdToTicketsMap;
     }
 
@@ -308,7 +302,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         };
         spawner->DespawnAllEntities(ticket, optionalArgs);
 
-        // Call GeoJSONSpawner EBus notification - Spawn
+        // Call GeoJSONSpawner EBus notification - Despawn
         GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntityDespawn, ticket);
     }
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -260,12 +260,12 @@ namespace GeoJSONSpawner::GeoJSONUtils
     AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> SpawnEntities(
         AZStd::unordered_map<int, AZStd::vector<TicketToSpawnPair>>& ticketsToSpawn)
     {
-        SpawnInfo broadcastSpawnInfo = SpawnInfo{ }; // Spawn Info used in GeoJSONSpawner EBus notify.
-        SpawnStatus spawnStatusCode = SpawnStatus::Success; // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
+        // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
+        SpawnStatus spawnStatusCode = SpawnStatus::Success;
 
         // Call GeoJSONSpawner EBus notification - Begin
-        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnBegin, broadcastSpawnInfo);
-        
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnBegin);
+
         auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
         AZ_Assert(spawner, "Unable to get spawnable entities definition.");
 
@@ -282,9 +282,9 @@ namespace GeoJSONSpawner::GeoJSONUtils
             {
                 spawner->SpawnAllEntities(ticketToSpawn.first, ticketToSpawn.second);
                 groupIdToTicketsMap.at(groupIdToSpawn.first).emplace_back(AZStd::move(ticketToSpawn.first));
-                
+
                 // Call GeoJSONSpawner EBus notification - Spawn
-                GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitySpawn);
+                GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitySpawn, ticketToSpawn.first);
             }
         }
 
@@ -295,8 +295,8 @@ namespace GeoJSONSpawner::GeoJSONUtils
         }
 
         // Call GeoJSONSpawner EBus notification - Finished
-        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnFinished, broadcastSpawnInfo, spawnStatusCode);
-        
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitiesSpawnFinished, groupIdToTicketsMap, spawnStatusCode);
+
         return groupIdToTicketsMap;
     }
 
@@ -312,7 +312,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         spawner->DespawnAllEntities(ticket, optionalArgs);
 
         // Call GeoJSONSpawner EBus notification - Spawn
-        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntityDespawn);
+        GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntityDespawn, ticket);
     }
 
     AZStd::unordered_map<AZStd::string, GeoJSONSpawnableAssetConfiguration> GetSpawnableAssetFromVector(
@@ -596,10 +596,5 @@ namespace GeoJSONSpawner::GeoJSONUtils
     bool IsTerrainAvailable()
     {
         return AzFramework::Terrain::TerrainDataRequestBus::HasHandlers();
-    }
-
-    void SpawnInfo::Reflect(AZ::ReflectContext* context)
-    {
-
     }
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -263,9 +263,6 @@ namespace GeoJSONSpawner::GeoJSONUtils
         auto spawner = AZ::Interface<AzFramework::SpawnableEntitiesDefinition>::Get();
         AZ_Assert(spawner, "Unable to get spawnable entities definition.");
 
-        // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
-        SpawnDespawnStatus spawnStatusCode = spawner ? SpawnDespawnStatus::Success : SpawnDespawnStatus::Fail;
-
         AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> groupIdToTicketsMap;
         for (auto& groupIdToSpawn : ticketsToSpawn)
         {
@@ -281,11 +278,6 @@ namespace GeoJSONSpawner::GeoJSONUtils
                 // Call GeoJSONSpawner EBus notification - Spawn
                 GeoJSONSpawnerNotificationBus::Broadcast(&GeoJSONSpawnerInterface::OnEntitySpawn, ticketToSpawn.first);
             }
-        }
-
-        if (groupIdToTicketsMap.empty())
-        {
-            spawnStatusCode |= SpawnDespawnStatus::Fail;
         }
 
         return groupIdToTicketsMap;

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -267,7 +267,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         AZ_Assert(spawner, "Unable to get spawnable entities definition.");
 
         // Spawn Status Code used for GeoJSONSpawner EBus notify - OnEntitiesSpawnFinished.
-        SpawnStatus spawnStatusCode = spawner ? SpawnStatus::Success : SpawnStatus::Fail;
+        SpawnDespawnStatus spawnStatusCode = spawner ? SpawnDespawnStatus::Success : SpawnDespawnStatus::Fail;
 
         AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> groupIdToTicketsMap;
         for (auto& groupIdToSpawn : ticketsToSpawn)
@@ -288,7 +288,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
 
         if (groupIdToTicketsMap.empty())
         {
-            spawnStatusCode |= SpawnStatus::Fail;
+            spawnStatusCode |= SpawnDespawnStatus::Fail;
         }
 
         // Call GeoJSONSpawner EBus notification - Finished

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -10,7 +10,7 @@
 
 #include "GeoJSONSpawnerUtils.h"
 #include "Schemas/GeoJSONSchema.h"
-#include <GeoJSONSpawner/GeoJSONSpawnerBus.h>
+#include "GeoJSONSpawner/GeoJSONSpawnerBus.h"
 
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/IO/FileIO.h>

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
@@ -588,4 +588,5 @@ namespace GeoJSONSpawner::GeoJSONUtils
     {
         return AzFramework::Terrain::TerrainDataRequestBus::HasHandlers();
     }
+
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -181,19 +181,20 @@ namespace GeoJSONSpawner::GeoJSONUtils
     [[nodiscard]] bool IsTerrainAvailable();
 
     /**
-     * @brief Flags representing the status of an GeoJSONSpawner::Spawn() operation.
+     * @brief Flags representing the status of GeoJSONSpawner operations Spawnd and Despawn.
      *
-     * SpawnStatus provides various status indicators for entity spawning.
-     * These flags help track whether spawning was successful, stopped, or failed.
+     * Provides various status indicators for entity spawning / despawning.
+     * These flags help to track or filter mentioned operations.
      */
     enum class SpawnStatus : uint8_t
     {
         Success = 0, ///< Operation succeeded.
-        Fail = 1 << 0, ///< Generic failure.
+        Fail = 1 << 0, ///< Operation failed, generic result.
         Stopped = 1 << 1, ///< Spawning was stopped prematurely but not necessarily a failure.
-        Warning = 1 << 2, ///< An warning or error occurred during spawning (potentially recoverable).
+        Warning = 1 << 2, ///< An warning or error occurred during spawning / despawning (potentially recoverable).
+        Invalid = 1 << 3, ///< Something went wrong while spawning / despawning.
     };
 
-    /// Enable bitwise operations for SpawnStatus.
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnStatus);
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnStatus)
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -196,17 +196,4 @@ namespace GeoJSONSpawner::GeoJSONUtils
 
     /// Enable bitwise operations for SpawnStatus.
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnStatus);
-
-    /**
-     * @brief Structure holding data related to GeoJSONSpawner entity spawning.
-     *
-     * SpawnInfo contains information about the entities to be spawned, the physics scene
-     * they belong to, and the parent entity responsible for the spawn operation.
-     */
-    struct SpawnInfo
-    {
-        AZ_TYPE_INFO(SpawnInfo, GeoJSONSpawnerSpawnInfoTypeId);
-        static void Reflect(AZ::ReflectContext* context);
-
-    };
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -195,7 +195,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         Invalid = 1 << 3, ///< Something went wrong while spawning / despawning.
 
     };
-
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnDespawnStatus);
-    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnDespawnStatus)
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnDespawnStatus);
+
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -186,15 +186,16 @@ namespace GeoJSONSpawner::GeoJSONUtils
      * Provides various status indicators for entity spawning / despawning.
      * These flags help to track or filter mentioned operations.
      */
-    enum class SpawnStatus : uint8_t
+    enum class SpawnDespawnStatus : uint8_t
     {
         Success = 0, ///< Operation succeeded.
         Fail = 1 << 0, ///< Operation failed, generic result.
         Stopped = 1 << 1, ///< Spawning was stopped prematurely but not necessarily a failure.
         Warning = 1 << 2, ///< An warning or error occurred during spawning / despawning (potentially recoverable).
         Invalid = 1 << 3, ///< Something went wrong while spawning / despawning.
+
     };
 
-    AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnStatus);
-    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnStatus)
+    AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnDespawnStatus);
+    AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnDespawnStatus)
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -179,4 +179,37 @@ namespace GeoJSONSpawner::GeoJSONUtils
     //! This function checks if the Terrain is available in the level.
     //! @returns True if level has any valid Terrain handlers, false otherwise.
     [[nodiscard]] bool IsTerrainAvailable();
+
+    /**
+     * @brief Flags representing the status of an GeoJSONSpawner::Spawn() operation.
+     *
+     * SpawnStatus provides various status indicators for entity spawning.
+     * These flags help track whether spawning was successful, stopped, or failed.
+     */
+    enum class SpawnStatus : uint8_t
+    {
+        Success = 0, ///< Operation succeeded.
+        Fail = 1 << 0, ///< Generic failure.
+        Stopped = 1 << 1, ///< Spawning was stopped prematurely but not necessarily a failure.
+        Warning = 1 << 2, ///< An warning or error occurred during spawning (potentially recoverable).
+    };
+
+    /// Enable bitwise operations for SpawnStatus.
+    AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnStatus);
+
+    /**
+     * @brief Structure holding data related to GeoJSONSpawner entity spawning.
+     *
+     * SpawnInfo contains information about the entities to be spawned, the physics scene
+     * they belong to, and the parent entity responsible for the spawn operation.
+     */
+    struct SpawnInfo
+    {
+        AZ_TYPE_INFO(SpawnInfo, GeoJSONSpawnerSpawnInfoTypeId);
+        static void Reflect(AZ::ReflectContext* context);
+
+        // AZStd::vector<CsvSpawnableEntityInfo> m_entitiesToSpawn; ///< List of entities to spawn.
+        AZStd::string m_physicsSceneName; ///< Name of the physics scene where entities will be spawned.
+        AZ::EntityId m_spawnerParentEntityId; ///< Parent entity ID managing the spawn process.
+    };
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -208,8 +208,5 @@ namespace GeoJSONSpawner::GeoJSONUtils
         AZ_TYPE_INFO(SpawnInfo, GeoJSONSpawnerSpawnInfoTypeId);
         static void Reflect(AZ::ReflectContext* context);
 
-        // AZStd::vector<CsvSpawnableEntityInfo> m_entitiesToSpawn; ///< List of entities to spawn.
-        AZStd::string m_physicsSceneName; ///< Name of the physics scene where entities will be spawned.
-        AZ::EntityId m_spawnerParentEntityId; ///< Parent entity ID managing the spawn process.
     };
 } // namespace GeoJSONSpawner::GeoJSONUtils

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -181,7 +181,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
     [[nodiscard]] bool IsTerrainAvailable();
 
     /**
-     * @brief Flags representing the status of GeoJSONSpawner operations Spawnd and Despawn.
+     * @brief Flags representing the status of GeoJSONSpawner operations Spawn and Despawn.
      *
      * Provides various status indicators for entity spawning / despawning.
      * These flags help to track or filter mentioned operations.

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.cpp
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.cpp
@@ -1,0 +1,62 @@
+#include "SpawnTicketMapWrapper.h"
+
+namespace GeoJSONSpawner::GeoJSONWrappers
+{
+    void SpawnTicketMapWrapper::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+            behaviorContext->Class<SpawnTicketMapWrapper>("SpawnTicketMapWrapper")
+                ->Attribute(AZ::Script::Attributes::Category, "GeoJSONSpawner/Wrappers")
+                ->Method("Insert", &SpawnTicketMapWrapper::Insert)
+                ->Method("Clear", &SpawnTicketMapWrapper::Clear)
+                ->Method("GetKeys", &SpawnTicketMapWrapper::GetKeys)
+                ->Method("GetValues", &SpawnTicketMapWrapper::GetValues);
+        }
+    }
+
+    void SpawnTicketMapWrapper::Insert(int key, const AzFramework::EntitySpawnTicket& ticket)
+    {
+        m_map[key].push_back(ticket);
+    }
+
+    void SpawnTicketMapWrapper::Clear()
+    {
+        m_map.clear();
+    }
+
+    AZStd::vector<int> SpawnTicketMapWrapper::GetKeys() const
+    {
+        AZStd::vector<int> keys;
+        for (const auto& pair : m_map)
+        {
+            keys.push_back(pair.first);
+        }
+        return keys;
+    }
+
+    AZStd::vector<AzFramework::EntitySpawnTicket> SpawnTicketMapWrapper::GetValues(int key) const
+    {
+        auto it = m_map.find(key);
+        if (it != m_map.end())
+        {
+            return it->second;
+        }
+        return {};
+    }
+
+    void SpawnTicketMapWrapper::SetValues(int key, const AZStd::vector<AzFramework::EntitySpawnTicket>& values)
+    {
+        m_map[key] = values;
+    }
+
+    const AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& SpawnTicketMapWrapper::GetMap() const
+    {
+        return m_map;
+    }
+
+    void SpawnTicketMapWrapper::SetMap(const AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& m_map)
+    {
+        this->m_map = m_map;
+    }
+} // namespace GeoJSONSpawner::GeoJSONWrappers

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "GeoJSONSpawner/GeoJSONSpawnerTypeIds.h"
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/std/containers/unordered_map.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
+
+namespace GeoJSONSpawner::GeoJSONWrappers
+{
+    class SpawnTicketMapWrapper
+    {
+    public:
+        AZ_TYPE_INFO(SpawnTicketMapWrapper, GeoJSONSpawnerSpawnTicketMapWrapperTypeId);
+        AZ_CLASS_ALLOCATOR(SpawnTicketMapWrapper, AZ::SystemAllocator, 0);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        void Insert(int key, const AzFramework::EntitySpawnTicket& ticket);
+        void Clear();
+        [[nodiscard]] AZStd::vector<int> GetKeys() const;
+        [[nodiscard]] AZStd::vector<AzFramework::EntitySpawnTicket> GetValues(int key) const;
+        [[nodiscard]] const AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& GetMap() const;
+        void SetValues(int key, const AZStd::vector<AzFramework::EntitySpawnTicket>& values);
+        void SetMap(const AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>>& m_map);
+
+    private:
+        AZStd::unordered_map<int, AZStd::vector<AzFramework::EntitySpawnTicket>> m_map;
+    };
+} // namespace GeoJSONSpawner::GeoJSONWrappers

--- a/Gems/GeoJSONSpawner/Code/geojsonspawner_private_files.cmake
+++ b/Gems/GeoJSONSpawner/Code/geojsonspawner_private_files.cmake
@@ -9,6 +9,8 @@ set(FILES
     Source/GeoJSONSpawner/Schemas/GeoJSONSchema.h
     Source/GeoJSONSpawner/GeoJSONSpawnerUtils.cpp
     Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+    Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.cpp
+    Source/GeoJSONSpawner/Wrappers/SpawnTicketMapWrapper.h
     Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.cpp
     Source/GeoJSONSpawner/EditorConfigurations/GeoJSONSpawnerEditorTerrainSettingsConfig.h
 )

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,22 @@ Example of supported GeoJSON:
 }
 
 ```
+## API
+
+This Gem has defined notification bus - `GeoJSONSpawnerNotificationBus`.
+
+Available functions:
+
+| Function                             | Trigger Event                  | Description                                                |
+|--------------------------------------|--------------------------------|------------------------------------------------------------|
+| `OnEntitiesSpawnBegin()`             | When spawning starts           | Notifies when batch spawning begins.                       |
+| `OnEntitiesSpawnFinished()`          | When spawning ends             | Provides a list of spawned entities and the status code.   |
+| `OnEntitiesDespawnBegin()`           | When despawning starts         | Notifies when batch despawning begins.                     |
+| `OnEntitiesDespawnFinished()`        | When despawning ends           | Provides a list of despawned entities and the status code. |
+| `OnEntitySpawn()`                    | When a single entity spawns    | Called per one entity spawn.                               |
+| `OnEntityDespawn()`                  | When a single entity despawns  | Called per one entity despawn.                             |
+
+> *Supports **Lua** and **Script Canvas***
 
 # GeoJSONSpawnerROS2
 


### PR DESCRIPTION
## About
This PR introduces a notification bus for the Geo Json Spawner.

> *Supports **Lua** and **Script Canvas***

It allows triggering actions:

| Function                             | Trigger Event                  | Description                                                |
|--------------------------------------|--------------------------------|------------------------------------------------------------|
| `OnEntitiesSpawnBegin()`             | When spawning starts           | Notifies when batch spawning begins.                       |
| `OnEntitiesSpawnFinished()`          | When spawning ends             | Provides a list of spawned entities and the status code.   |
| `OnEntitiesDespawnBegin()`           | When despawning starts         | Notifies when batch despawning begins.                     |
| `OnEntitiesDespawnFinished()`        | When despawning ends           | Provides a list of despawned entities and the status code. |
| `OnEntitySpawn()`                    | When a single entity spawns    | Called per one entity spawn.                               |
| `OnEntityDespawn()`                  | When a single entity despawns  | Called per one entity despawn.                             |

This is particularly useful when there is a need to react to the *"when entities are spawned"* and execute specific logic when it happens.

**Status Code** is a flag containing:
- `Success` - Operation succeeded.
- `Fail` - Generic failure.
- `Stopped` - Spawning was stopped prematurely but not necessarily a failure.
- `Warning` - A warning or error occurred during spawning (potentially recoverable).

The result can be a `Success` with some `Warnings` that occurred or a `Failure` that `Stopped` action and generated some `Warnings`.
This gives more flexibility to filter actions when spawn / despawn is finished.
