### PR TITLE
Add cl_hide_menu_bar console flag

### DIFF
--- a/Gems/ImGuiProvider/Code/Source/Clients/ImGuiProviderSystemComponent.cpp
+++ b/Gems/ImGuiProvider/Code/Source/Clients/ImGuiProviderSystemComponent.cpp
@@ -2,6 +2,7 @@
 #include "ImGuiProviderSystemComponent.h"
 #include <Atom/Feature/ImGui/SystemBus.h>
 #include <AzCore/Component/EntityId.h>
+#include <AzCore/Console/IConsole.h>
 #include <AzCore/Debug/Trace.h>
 #include <AzCore/base.h>
 #include <AzCore/std/algorithm.h>
@@ -12,7 +13,6 @@
 #include <AzCore/std/utility/pair.h>
 #include <AzFramework/Viewport/ViewportBus.h>
 #include <ImGui/ImGuiPass.h>
-#include <AzCore/Console/IConsole.hr>
 
 #include <ImGuiBus.h>
 #include <ImGuiProvider/ImGuiProviderBus.h>

--- a/readme.md
+++ b/readme.md
@@ -382,6 +382,10 @@ This gem adds support for displaying user defined ImGui GUI. Users can define th
 
 Below example on how to register new feature during component activation:
 
+Visibility of the GUI menu bar can be overridden at the app start using `-cl_hide_menu_bar=1`.
+Setting the flag effectively disables the GUI.
+
+
 ```cpp
 void ExampleComponent::Activate()
 {


### PR DESCRIPTION
This PR adds console flag cl_hide_menu_bar that controls if menu bar is visible.
Default value is false. To invoke execute your app with `-cl_hide_menu_bar=1`