### PR TITLE
Quick Geo Json Fix - missing type info specialize

### DIFF
--- a/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
+++ b/Gems/GeoJSONSpawner/Code/Include/GeoJSONSpawner/GeoJSONSpawnerTypeIds.h
@@ -42,4 +42,7 @@ namespace GeoJSONSpawner
     inline constexpr const char* GeoJSONSpawnerRequestsTypeId = "{EE523E9E-CFDF-4590-BBDE-054848BBA790}";
     inline constexpr const char* GeoJSONSpawnerInterfaceTypeId = "{4770B38A-D018-4184-A672-3F9155B7BEE7}";
     inline constexpr const char* GeoJSONSpawnerNotificationBusHandlerTypeId = "{9D8C5E99-7151-4AA4-9B5F-2D8AE2F097F7}";
+
+    // Enums
+    inline constexpr const char* SpawnDespawnStatusTypeId = "{1E22A24E-8365-4CC7-8B99-CC0EF0B25B13}";
 } // namespace GeoJSONSpawner

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -195,6 +195,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         Invalid = 1 << 3, ///< Something went wrong while spawning / despawning.
 
     };
+    AZ_TYPE_INFO_SPECIALIZE(GeoJSONSpawner::GeoJSONUtils::SpawnDespawnStatus, "{1E22A24E-8365-4CC7-8B99-CC0EF0B25B13}");
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnDespawnStatus);
     AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnDespawnStatus);
 

--- a/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
+++ b/Gems/GeoJSONSpawner/Code/Source/GeoJSONSpawner/GeoJSONSpawnerUtils.h
@@ -195,7 +195,7 @@ namespace GeoJSONSpawner::GeoJSONUtils
         Invalid = 1 << 3, ///< Something went wrong while spawning / despawning.
 
     };
-    AZ_TYPE_INFO_SPECIALIZE(GeoJSONSpawner::GeoJSONUtils::SpawnDespawnStatus, "{1E22A24E-8365-4CC7-8B99-CC0EF0B25B13}");
+    AZ_TYPE_INFO_SPECIALIZE(GeoJSONSpawner::GeoJSONUtils::SpawnDespawnStatus, SpawnDespawnStatusTypeId);
     AZ_DEFINE_ENUM_BITWISE_OPERATORS(SpawnDespawnStatus);
     AZ_DEFINE_ENUM_RELATIONAL_OPERATORS(SpawnDespawnStatus);
 


### PR DESCRIPTION
## About
Adding missing `AZ_TYPE_INFO_SPECIALIZE` to enum `SpawnDespawnStatus`.

## Fixes issue: 
```
==================================================================
System: Trace::Assert
 /opt/O3DE/24.09.2/Code/Framework/AzCore/./AzCore/Serialization/SerializeContextEnum.inl(146): (139703592611072) 'SerializeContext::EnumBuilder AZ::SerializeContext::Enum(AZ::SerializeContext::IObjectFactory *) [EnumType = GeoJSONSpawner::GeoJSONUtils::SpawnDespawnStatus]'
System: Enum Type has invalid AZ::TypeId. Has it been specialized with AZ_TYPE_INFO_INTERNAL_SPECIALIZE macro?
System: ------------------------------------------------
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System:  -- error: unable to obtain symbol name for this frame
System: std::__detail::__from_chars_alpha_to_num(char) (+0x85c1aa) [0x7f0f41d24b1a]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x117629) [0x7f0f415dff99]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x857e34) [0x7f0f41d207a4]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x221644) [0x7f0f416e9fb4]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x218197) [0x7f0f416e0b07]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x2202f6) [0x7f0f416e8c66]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x21a626) [0x7f0f416e2f96]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x21ad9c) [0x7f0f416e370c]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x86d990) [0x7f0f41d36300]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x859494) [0x7f0f41d21e04]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x856a01) [0x7f0f41d1f371]
System: std::__detail::__from_chars_alpha_to_num(char) (+0x85670f) [0x7f0f41d1f07f]
System: std::__detail::_Executor<char const*, std::allocator<std::__cxx11::sub_match<char const*> >, std::__cxx11::regex_traits<char>, true>::_M_lookahead(long) (+0x27fded) [0x7f0f44a0fe9d]
System: std::enable_if<__and_<std::__not_<std::__is_tuple_like<AzQtComponents::SearchTypeFilter> >, std::is_move_constructible<AzQtComponents::SearchTypeFilter>, std::is_move_assignable<AzQtComponents::SearchTypeFilter> >::value, void>::type std::swap<AzQtCompon
System: AzToolsFramework::CryEditPythonHandler::Reflect(AZ::ReflectContext*) (+0x4336) [0x7f0f41270886]
System: CryEditMain (+0x48d) [0x7f0f4131603d]
System:  -- error: unable to obtain symbol name for this frame
System: __libc_init_first (+0x90) [0x7f0f46a29d90]
System: __libc_start_main (+0x80) [0x7f0f46a29e40]
System:  -- error: unable to obtain symbol name for this frame
System: ==================================================================
System: ====Assert added to ignore list by spec and verbosity setting.====
```