### PR TITLE
Added initial restoration policy field

### DIFF
--- a/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlRequestBus.h
+++ b/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlRequestBus.h
@@ -23,6 +23,13 @@ namespace ROS2PoseControl
         TF2
     };
 
+    enum class InitialPoseRestorationPolicy
+    {
+        Never,
+        Once,
+        Everytime
+    };
+
     //! Interface for the ROS2PoseControl
     //! Used for configuring the ROS2PoseControl at runtime
     class ROS2PoseControlRequests : public AZ::ComponentBus
@@ -31,7 +38,7 @@ namespace ROS2PoseControl
         AZ_RTTI(ROS2PoseControlRequests, ROS2PoseControlRequestsTypeId)
 
         //! Set the tracking mode
-        //! @param trackingMode - new tracking mode, to check available tracking modes @see ROS2PoseControlConfiguration
+        //! @param trackingMode - new tracking mode, to check available tracking modes @see TrackingMode
         virtual void SetTrackingMode(TrackingMode trackingMode) = 0;
 
         //! Set the target frame that is used in the TF2 tracking mode
@@ -49,6 +56,10 @@ namespace ROS2PoseControl
         //! Change the prefab's rigid bodies to either Kinematic (enable==true) or Simulated (enable==false)
         //! @param enable - enable/disable flag
         virtual void SetRigidBodiesToKinematic(bool enable) = 0;
+
+        //! Set the initial pose restore policy
+        //! @param initialPoseRestorationPolicy - new initial pose restore policy, to check available policies @see InitialPoseRestorationPolicy
+        virtual void SetInitialPoseRestorationPolicy(InitialPoseRestorationPolicy initialPoseRestorationPolicy) = 0;
 
         //! Apply configuration of the ROS2PoseControl in its current state. In general this function reinitialize the ROS2 intestines of
         //! the ROS2PoseControl

--- a/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlRequestBus.h
+++ b/Gems/ROS2PoseControl/Code/Include/ROS2PoseControl/ROS2PoseControlRequestBus.h
@@ -58,7 +58,8 @@ namespace ROS2PoseControl
         virtual void SetRigidBodiesToKinematic(bool enable) = 0;
 
         //! Set the initial pose restore policy
-        //! @param initialPoseRestorationPolicy - new initial pose restore policy, to check available policies @see InitialPoseRestorationPolicy
+        //! @param initialPoseRestorationPolicy - new initial pose restore policy, to check available policies @see
+        //! InitialPoseRestorationPolicy
         virtual void SetInitialPoseRestorationPolicy(InitialPoseRestorationPolicy initialPoseRestorationPolicy) = 0;
 
         //! Apply configuration of the ROS2PoseControl in its current state. In general this function reinitialize the ROS2 intestines of

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -173,6 +173,12 @@ namespace ROS2PoseControl
         }
     }
 
+    void ROS2PoseControl::SetInitialPoseRestorationPolicy(InitialPoseRestorationPolicy initialPoseRestorationPolicy)
+    {
+        m_configuration.m_initialPoseRestorationPolicy = initialPoseRestorationPolicy;
+        m_configurationChanged = true;
+    }
+
     void ROS2PoseControl::ApplyConfiguration()
     {
         if (m_configurationChanged)
@@ -445,6 +451,25 @@ namespace ROS2PoseControl
         return offsetTransform;
     }
 
+    bool ROS2PoseControl::IsRestoreNeeded()
+    {
+        if (m_configuration.m_initialPoseRestorationPolicy == InitialPoseRestorationPolicy::Never ||
+            !(!m_configuration.m_enablePhysics || m_configuration.m_isKinematic))
+        {
+            return false;
+        }
+
+        if (m_configuration.m_initialPoseRestorationPolicy == InitialPoseRestorationPolicy::Once)
+        {
+            if (m_initialPositionRestored)
+            {
+                return false;
+            }
+            m_initialPositionRestored = true;
+        }
+        return true;
+    }
+
     void ROS2PoseControl::ApplyTransform(const AZ::Transform& transform)
     {
         if (transform.GetRotation().IsZero())
@@ -463,7 +488,7 @@ namespace ROS2PoseControl
         // then we want to restore the initial positions of all entities. These positions
         // may have changed before the physics or kinematics were enabled/disabled via
         // the EBus request
-        if (!m_initialPositionRestored && (!m_configuration.m_enablePhysics || m_configuration.m_isKinematic))
+        if (IsRestoreNeeded())
         {
             for (const auto& [entityId, localTM] : m_localTransforms)
             {

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -453,8 +453,7 @@ namespace ROS2PoseControl
 
     bool ROS2PoseControl::IsRestoreNeeded()
     {
-        if (m_configuration.m_initialPoseRestorationPolicy == InitialPoseRestorationPolicy::Never ||
-            !(!m_configuration.m_enablePhysics || m_configuration.m_isKinematic))
+        if (m_configuration.m_initialPoseRestorationPolicy == InitialPoseRestorationPolicy::Never)
         {
             return false;
         }
@@ -494,8 +493,6 @@ namespace ROS2PoseControl
             {
                 AZ::TransformBus::Event(entityId, &AZ::TransformBus::Events::SetLocalTM, localTM);
             }
-
-            m_initialPositionRestored = true;
         }
 
         AZ::Transform modifiedTransform = m_configuration.m_lockZAxis ? RemoveTilt(transform) : transform;

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -483,10 +483,6 @@ namespace ROS2PoseControl
             DisablePhysics();
         }
 
-        // If prefab has physics disabled or all of its rigid bodies are set to 'Kinematic'
-        // then we want to restore the initial positions of all entities. These positions
-        // may have changed before the physics or kinematics were enabled/disabled via
-        // the EBus request
         if (IsRestoreNeeded())
         {
             for (const auto& [entityId, localTM] : m_localTransforms)

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.h
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.h
@@ -115,6 +115,7 @@ namespace ROS2PoseControl
         void SetReferenceFrame(const AZStd::string& referenceFrame) override;
         void SetEnablePhysics(bool enable) override;
         void SetRigidBodiesToKinematic(bool enable) override;
+        void SetInitialPoseRestorationPolicy(InitialPoseRestorationPolicy initialPoseRestorationPolicy) override;
         void ApplyConfiguration() override;
 
         //! Initializes all ROS2-related things (rclcpp::Subscription, tf2_ros::Buffer etc.)
@@ -123,6 +124,10 @@ namespace ROS2PoseControl
         //! Deinitializes all ROS2-related things (rclcpp::Subscription, tf2_ros::Buffer etc.)
         //! Allows to reconfigure tracking mode in the runtime
         void DeinitializeROSConnection();
+
+        //! Checks if the inital pose of the prefab should be restored
+        //! @return boolean flag which determines whether the restore is needed or not
+        bool IsRestoreNeeded();
 
         // Tracks the entities that need physics reenabled.
         AZStd::unordered_set<AZ::EntityId> m_needsPhysicsReenable;

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
@@ -40,6 +40,7 @@ namespace ROS2PoseControl
         {
             serializeContext->Class<ROS2PoseControlConfiguration>()
                 ->Version(1)
+                ->Field("m_initialPoseRestorePolicy", &ROS2PoseControlConfiguration::m_initialPoseRestorationPolicy)
                 ->Field("m_tracking_mode", &ROS2PoseControlConfiguration::m_tracking_mode)
                 ->Field("m_poseTopicConfiguration", &ROS2PoseControlConfiguration::m_poseTopicConfiguration)
                 ->Field("m_targetFrame", &ROS2PoseControlConfiguration::m_targetFrame)
@@ -55,6 +56,14 @@ namespace ROS2PoseControl
             {
                 ec->Class<ROS2PoseControlConfiguration>("ROS2PoseControlConfiguration", "Sub configuration for ROS2PoseControl component")
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox,
+                        &ROS2PoseControlConfiguration::m_initialPoseRestorationPolicy,
+                        "Initial pose restore policy",
+                        "Initial pose restore policy")
+                    ->EnumAttribute(InitialPoseRestorationPolicy::Never, "Never")
+                    ->EnumAttribute(InitialPoseRestorationPolicy::Once, "Once")
+                    ->EnumAttribute(InitialPoseRestorationPolicy::Everytime, "Everytime")
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox,
                         &ROS2PoseControlConfiguration::m_tracking_mode,

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.h
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.h
@@ -54,5 +54,7 @@ namespace ROS2PoseControl
 
         bool m_enablePhysics{ true };
         bool m_isKinematic{ false };
+
+        InitialPoseRestorationPolicy m_initialPoseRestorationPolicy{ InitialPoseRestorationPolicy::Once };
     };
 } // namespace ROS2PoseControl


### PR DESCRIPTION
As in the title - this PR introduces the new field to the ROS2PoseControl component. This field supports three policies:
- Never - the inital position will never be restored
- Once - the initial position will be restored only once, with first goal pose request to the ROS2PoseControl (as it was before this PR). This policy is a default one.
- Everytime - the initial position will be restored with every goal pose request

Resolves #126 