### PR TITLE
Added early return if there is no registered ImGui Tabs

### DIFF
--- a/Gems/ImGuiProvider/Code/Source/Clients/ImGuiProviderSystemComponent.cpp
+++ b/Gems/ImGuiProvider/Code/Source/Clients/ImGuiProviderSystemComponent.cpp
@@ -105,6 +105,11 @@ namespace ImGuiProvider
 
         // imgui notification bus is called called only if debug menu is shown, so it cannot be reliably used for imgui displaying
 
+        if (m_registeredFeatures.empty())
+        {
+            return;
+        }
+
         if (IsDebugGUIDeactivated())
         {
             AZ::Render::ImGuiSystemRequestBus::BroadcastResult(m_currentImGuiContext, &AZ::Render::ImGuiSystemRequests::GetActiveContext);

--- a/Gems/ImGuizmo/gem.json
+++ b/Gems/ImGuizmo/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ImGuizmo",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "ImGuizmo",
     "license": "MIT",
     "license_url": "https://opensource.org/licenses/MIT",


### PR DESCRIPTION
This PR adds early return to prevent displaying empty tab at the top of the viewport in case when there is no ImGui tab registered