### PR TITLE
Fix cmake problem (see o3de#17605)

### DIFF
--- a/Gems/DisableMainView/Code/CMakeLists.txt
+++ b/Gems/DisableMainView/Code/CMakeLists.txt
@@ -123,7 +123,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
                 AZ::AzToolsFramework
                 Gem::Atom_RPI.Public
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/LevelModificationTools/Code/CMakeLists.txt
+++ b/Gems/LevelModificationTools/Code/CMakeLists.txt
@@ -126,7 +126,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/Pointcloud/Code/CMakeLists.txt
+++ b/Gems/Pointcloud/Code/CMakeLists.txt
@@ -138,7 +138,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::Atom_Utils.Static
                 Gem::Atom_Feature_Common.Static
                 Gem::AtomLyIntegration_CommonFeatures.Static

--- a/Gems/ROS2PoseControl/Code/CMakeLists.txt
+++ b/Gems/ROS2PoseControl/Code/CMakeLists.txt
@@ -135,7 +135,7 @@ if (PAL_TRAIT_BUILD_HOST_TOOLS)
             PUBLIC
             Gem::ROS2.Editor.Static
             AZ::AzToolsFramework
-            $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+            ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/RobotecRecordingTools/Code/CMakeLists.txt
+++ b/Gems/RobotecRecordingTools/Code/CMakeLists.txt
@@ -127,7 +127,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::AtomLyIntegration_CommonFeatures.Public
                 Gem::ROS2.Static
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/RobotecSpectatorCamera/Code/CMakeLists.txt
+++ b/Gems/RobotecSpectatorCamera/Code/CMakeLists.txt
@@ -121,7 +121,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
     )
 
     ly_add_target(

--- a/Gems/RobotecSplineTools/Code/CMakeLists.txt
+++ b/Gems/RobotecSplineTools/Code/CMakeLists.txt
@@ -128,7 +128,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::AtomLyIntegration_CommonFeatures.Static
                 Gem::ROS2.Editor.Static
     )

--- a/Gems/RobotecWatchdogTools/Code/CMakeLists.txt
+++ b/Gems/RobotecWatchdogTools/Code/CMakeLists.txt
@@ -129,7 +129,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::ROS2.Static
     )
 

--- a/Gems/SensorDebug/Code/CMakeLists.txt
+++ b/Gems/SensorDebug/Code/CMakeLists.txt
@@ -125,7 +125,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::ImGui.imguilib
                 Gem::ImGui
                 Gem::ROS2.Static


### PR DESCRIPTION
There used to be a problem with gem generator which makes gems impossible to build with newer `cmake` tools. Please see https://github.com/o3de/o3de/pull/17605 for details.