### PR TITLE
CSVSpawner and ROS2PoseControl update to 2505

### DIFF
--- a/Gems/CsvSpawner/Code/CMakeLists.txt
+++ b/Gems/CsvSpawner/Code/CMakeLists.txt
@@ -127,6 +127,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 Gem::ROS2.Editor.Static
+                Gem::LevelGeoreferencing.API
                 AZ::AzToolsFramework
                 ${gem_name}.Private.Object
     )

--- a/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerCsvParser.cpp
+++ b/Gems/CsvSpawner/Code/Source/CsvSpawner/CsvSpawnerCsvParser.cpp
@@ -14,7 +14,7 @@
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string.h>
 #include <AzFramework/Spawnable/SpawnableEntitiesInterface.h>
-#include <ROS2/Georeference/GeoreferenceBus.h>
+#include <Georeferencing/GeoreferenceBus.h>
 #include <csv/csv.hpp>
 
 namespace CsvSpawner::CsvSpawnerUtils
@@ -84,13 +84,13 @@ namespace CsvSpawner::CsvSpawnerUtils
                 }
                 else if (isWGSCoordinates)
                 {
-                    ROS2::WGS::WGS84Coordinate coordinate;
+                    Georeferencing::WGS::WGS84Coordinate coordinate;
                     coordinate.m_latitude = row[index_lat.value()].get<double>();
                     coordinate.m_longitude = row[index_lon.value()].get<double>();
                     coordinate.m_altitude = row[index_alt.value()].get<double>();
                     AZ::Vector3 coordinateInLevel = AZ::Vector3(-1);
-                    ROS2::GeoreferenceRequestsBus::BroadcastResult(
-                        coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
+                    Georeferencing::GeoreferenceRequestsBus::BroadcastResult(
+                        coordinateInLevel, &Georeferencing::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
                     AZ_Printf(
                         "TreeSpawnerEditorComponent",
                         "Converted WGS84 coordinate to level coordinate: %f, %f, %f WGS84: %f, %f, %f\n",

--- a/Gems/CsvSpawner/gem.json
+++ b/Gems/CsvSpawner/gem.json
@@ -21,7 +21,8 @@
   "requirements": "Requires ROS2 Gem",
   "documentation_url": "",
   "dependencies": [
-    "ROS2"
+    "ROS2",
+    "LevelGeoreferencing"
   ],
   "repo_uri": "",
   "compatible_engines": [],

--- a/Gems/CsvSpawner/gem.json
+++ b/Gems/CsvSpawner/gem.json
@@ -1,6 +1,6 @@
 {
   "gem_name": "CsvSpawner",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "display_name": "CsvSpawner",
   "license": "Apache-2.0",
   "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/Gems/ROS2PoseControl/Code/CMakeLists.txt
+++ b/Gems/ROS2PoseControl/Code/CMakeLists.txt
@@ -57,6 +57,7 @@ ly_add_target(
         Gem::ImGui.Static
         Gem::ROS2.Static
         Gem::ROS2.API
+        Gem::LevelGeoreferencing.API
 )
 
 target_depends_on_ros2_packages(${gem_name}.Private.Object geometry_msgs)

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -20,9 +20,9 @@
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
+#include <Georeferencing/GeoreferenceBus.h>
 #include <LmbrCentral/Scripting/TagComponentBus.h>
 #include <ROS2/Frame/ROS2FrameComponent.h>
-#include <ROS2/Georeference/GeoreferenceBus.h>
 #include <ROS2/Utilities/ROS2Conversions.h>
 #include <ROS2/Utilities/ROS2Names.h>
 #include <RigidBodyComponent.h>
@@ -291,7 +291,7 @@ namespace ROS2PoseControl
         }
         bool isWGS = m_configuration.m_useWGS && msg->header.frame_id == "wgs84";
 
-        if (isWGS && !ROS2::GeoreferenceRequestsBus::HasHandlers())
+        if (isWGS && !Georeferencing::GeoreferenceRequestsBus::HasHandlers())
         {
             AZ_Error(
                 "ROS2PoseControl",
@@ -304,15 +304,16 @@ namespace ROS2PoseControl
 
         if (isWGS)
         {
-            ROS2::WGS::WGS84Coordinate coordinate;
+            Georeferencing::WGS::WGS84Coordinate coordinate;
             AZ::Vector3 coordinateInLevel = AZ::Vector3(-1);
             AZ::Quaternion rotationInENU = AZ::Quaternion::CreateIdentity();
             coordinate.m_latitude = msg->pose.position.x;
             coordinate.m_longitude = msg->pose.position.y;
             coordinate.m_altitude = msg->pose.position.z;
-            ROS2::GeoreferenceRequestsBus::BroadcastResult(rotationInENU, &ROS2::GeoreferenceRequests::GetRotationFromLevelToENU);
-            ROS2::GeoreferenceRequestsBus::BroadcastResult(
-                coordinateInLevel, &ROS2::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
+            Georeferencing::GeoreferenceRequestsBus::BroadcastResult(
+                rotationInENU, &Georeferencing::GeoreferenceRequests::GetRotationFromLevelToENU);
+            Georeferencing::GeoreferenceRequestsBus::BroadcastResult(
+                coordinateInLevel, &Georeferencing::GeoreferenceRequests::ConvertFromWGS84ToLevel, coordinate);
 
             rotationInENU =
                 (rotationInENU.GetInverseFast() *

--- a/Gems/ROS2PoseControl/gem.json
+++ b/Gems/ROS2PoseControl/gem.json
@@ -22,6 +22,7 @@
     "documentation_url": "See the docs in the repo",
     "dependencies": [
         "ROS2",
+        "LevelGeoreferencing",
         "ImGui"
     ],
     "repo_uri": "",

--- a/Gems/ROS2PoseControl/gem.json
+++ b/Gems/ROS2PoseControl/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2PoseControl",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "display_name": "ROS2PoseControl",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Note that this is not a "Canonical" part of O3DE - those gems are third-party co
 
 | Gem name                   | Compatibility   |
 | -------------------------- | --------------- |
-| **CsvSpawner**             | incompatible    |
+| **CsvSpawner**             | compatible      |
 | **DisableMainView**        | not verified    |
 | **ExposeConsoleToRos**     | not verified    |
 | **GeoJSONSpawner**         | compatible      |
@@ -22,7 +22,7 @@ Note that this is not a "Canonical" part of O3DE - those gems are third-party co
 | **RobotecSpectatorCamera** | not verified    |
 | **RobotecSplineTools**     | incompatible    |
 | **RobotecWatchdogTools**   | not verified    |
-| **ROS2PoseControl**        | incompatible    |
+| **ROS2PoseControl**        | compatible      |
 | **ROS2ScriptIntegration**  | not verified    |
 | **SensorDebug**            | not verified    |
 | **Smoothing**              | not verified    |


### PR DESCRIPTION
This PR updates CSVSpawner and ROS2PoseControl to work with O3DE 2505