### PR TITLE
Clean up licensing information; clean up gem.json files

### DIFF
--- a/Gems/CsvSpawner/gem.json
+++ b/Gems/CsvSpawner/gem.json
@@ -23,7 +23,7 @@
   "dependencies": [
     "ROS2"
   ],
-  "repo_uri": "",
+  "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
   "compatible_engines": [],
   "engine_api_dependencies": [],
   "restricted": "CsvSpawner"

--- a/Gems/DisableMainView/gem.json
+++ b/Gems/DisableMainView/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "Robotec.ai",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Disable the main view, usable for debugging",
     "canonical_tags": [
@@ -21,7 +21,7 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "DisableMainView"

--- a/Gems/ExposeConsoleToRos/gem.json
+++ b/Gems/ExposeConsoleToRos/gem.json
@@ -20,8 +20,10 @@
     "icon_path": "preview.png",
     "requirements": "User's caution is advised",
     "documentation_url": "https://github.com/RobotecAI/robotec-o3de-tools/blob/main/readme.md",
-    "dependencies": ["ROS2"],
-    "repo_uri": "",
+    "dependencies": [
+        "ROS2"
+    ],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ExposeConsoleToRos"

--- a/Gems/GeoJSONSpawner/gem.json
+++ b/Gems/GeoJSONSpawner/gem.json
@@ -23,7 +23,7 @@
   "dependencies": [
     "ROS2"
   ],
-  "repo_uri": "",
+  "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
   "compatible_engines": [],
   "engine_api_dependencies": [],
   "restricted": "GeoJSONSpawner"

--- a/Gems/GeoJSONSpawnerROS2/gem.json
+++ b/Gems/GeoJSONSpawnerROS2/gem.json
@@ -24,7 +24,7 @@
         "GeoJSONSpawner",
         "ROS2"
     ],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "GeoJSONSpawnerROS2"

--- a/Gems/ImGuiProvider/gem.json
+++ b/Gems/ImGuiProvider/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "Robotec.ai",
-    "origin_url": "",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Gem is meant to manage displaying of ImGui registered by user along with the debug ImGui available in O3DE",
     "canonical_tags": [
@@ -21,7 +21,7 @@
     "requirements": "ImGui",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ImGuiProvider"

--- a/Gems/ImGuizmo/gem.json
+++ b/Gems/ImGuizmo/gem.json
@@ -4,8 +4,8 @@
     "display_name": "ImGuizmo",
     "license": "MIT",
     "license_url": "https://opensource.org/licenses/MIT",
-    "origin": "Robotec.AI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Gem introduces gizmos in runtime. It is based on ImGuizmo by Cedric Guillemet",
     "canonical_tags": [
@@ -20,8 +20,10 @@
     "icon_path": "preview.png",
     "requirements": "ImGui",
     "documentation_url": "",
-    "dependencies": ["ImGui"],
-    "repo_uri": "",
+    "dependencies": [
+        "ImGui"
+    ],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ImGuizmo"

--- a/Gems/LevelModificationTools/gem.json
+++ b/Gems/LevelModificationTools/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "Robotec AI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Handy interface to replace / modify entities in runtime.",
     "canonical_tags": [

--- a/Gems/Pointcloud/gem.json
+++ b/Gems/Pointcloud/gem.json
@@ -4,7 +4,7 @@
     "display_name": "Pointcloud",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "Robotec.AI",
+    "origin": "Robotec.ai",
     "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Tool Gem to visualize point clouds",
@@ -25,7 +25,9 @@
         "Atom"
     ],
     "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
-    "compatible_engines": ["o3de>=2.3.0"],
+    "compatible_engines": [
+        "o3de>=2.3.0"
+    ],
     "engine_api_dependencies": [],
     "restricted": "Pointcloud"
 }

--- a/Gems/ROS2PoseControl/gem.json
+++ b/Gems/ROS2PoseControl/gem.json
@@ -4,7 +4,7 @@
     "display_name": "ROS2PoseControl",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "RobotecAI",
+    "origin": "Robotec.ai",
     "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Allows for control of a entities pose using ROS2",
@@ -24,7 +24,7 @@
         "ROS2",
         "ImGui"
     ],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ROS2PoseControl"

--- a/Gems/ROS2ScriptIntegration/gem.json
+++ b/Gems/ROS2ScriptIntegration/gem.json
@@ -2,10 +2,10 @@
     "gem_name": "ROS2ScriptIntegration",
     "version": "1.0.0",
     "display_name": "ROS2ScriptIntegration",
-    "license": "Apache-2.0 or MIT",
+    "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "Robotec.AI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "It allows to integrate ROS 2 with scripting languages like Script Canvas and Lua",
     "canonical_tags": [
@@ -20,8 +20,10 @@
     "icon_path": "preview.png",
     "requirements": "This gem requires ROS2 to be installed and running and ROS 2 Gem",
     "documentation_url": "",
-    "dependencies": ["ROS2"],
-    "repo_uri": "",
+    "dependencies": [
+        "ROS2"
+    ],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ROS2ScriptIntegration"

--- a/Gems/RandomizeUtils/gem.json
+++ b/Gems/RandomizeUtils/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "Robotec.ai",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "This gem allows to randomize prefab on spawning.",
     "canonical_tags": [
@@ -21,7 +21,7 @@
     "requirements": "None",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "RandomizeUtils"

--- a/Gems/RobotecRecordingTools/gem.json
+++ b/Gems/RobotecRecordingTools/gem.json
@@ -2,12 +2,12 @@
     "gem_name": "RobotecRecordingTools",
     "version": "1.0.0",
     "display_name": "RobotecRecordingTools",
-    "license": "License used i.e. Apache-2.0 or MIT",
-    "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
-    "origin": "The name of the originator or creator",
-    "origin_url": "The website for this Gem",
+    "license": "Apache-2.0",
+    "license_url": "https://opensource.org/licenses/Apache-2.0",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
-    "summary": "A short description of this Gem",
+    "summary": "A toolset for joystick-controlled cameras and spline animation tools.",
     "canonical_tags": [
         "Gem"
     ],
@@ -18,10 +18,10 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "Notice of any requirements for this Gem i.e. This requires X other gem",
-    "documentation_url": "Link to any documentation of your Gem",
+    "requirements": "",
+    "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "RobotecRecordingTools"

--- a/Gems/RobotecSpectatorCamera/gem.json
+++ b/Gems/RobotecSpectatorCamera/gem.json
@@ -5,7 +5,7 @@
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
     "origin": "Robotec.ai",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Camera that works in two modes - ThirdPerson and FreeFlying",
     "canonical_tags": [
@@ -21,7 +21,7 @@
     "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "RobotecSpectatorCamera"

--- a/Gems/RobotecSplineTools/gem.json
+++ b/Gems/RobotecSplineTools/gem.json
@@ -4,8 +4,8 @@
     "display_name": "SplineTools",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "RobotecAI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "A swiss army knife of splines for O3DE",
     "canonical_tags": [
@@ -18,10 +18,12 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "No requirements",
+    "requirements": "This Gem requires ROS2 Gem",
     "documentation_url": "",
-    "dependencies": ["ROS2"],
-    "repo_uri": "",
+    "dependencies": [
+        "ROS2"
+    ],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "SplineTools"

--- a/Gems/RobotecWatchdogTools/gem.json
+++ b/Gems/RobotecWatchdogTools/gem.json
@@ -2,10 +2,10 @@
     "gem_name": "WatchdogTools",
     "version": "1.0.0",
     "display_name": "Watchdog Tools",
-    "license": "Apache-2.0 or MIT",
+    "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "Robotec.AI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "It monitors if system requirements are met, logs warnings and shortens the feedback loop in case of errors",
     "canonical_tags": [
@@ -18,10 +18,10 @@
         "Linux"
     ],
     "icon_path": "preview.png",
-    "requirements": "The Gem does not have dependencies to minimize chance that it fails to load",
+    "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "WatchdogTools"

--- a/Gems/SensorDebug/gem.json
+++ b/Gems/SensorDebug/gem.json
@@ -2,12 +2,12 @@
     "gem_name": "SensorDebug",
     "version": "1.0.0",
     "display_name": "SensorDebug",
-    "license": "License used i.e. Apache-2.0 or MIT",
-    "license_url": "Link to the license web site i.e. https://opensource.org/licenses/Apache-2.0",
-    "origin": "The name of the originator or creator",
-    "origin_url": "The website for this Gem",
+    "license": "Apache-2.0",
+    "license_url": "https://opensource.org/licenses/Apache-2.0",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
-    "summary": "A short description of this Gem",
+    "summary": "A tool to enable/disable sensor during the game mode.",
     "canonical_tags": [
         "Gem"
     ],
@@ -18,10 +18,10 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "Notice of any requirements for this Gem i.e. This requires X other gem",
-    "documentation_url": "Link to any documentation of your Gem",
+    "requirements": "",
+    "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "SensorDebug"

--- a/Gems/Smoothing/gem.json
+++ b/Gems/Smoothing/gem.json
@@ -3,11 +3,11 @@
     "version": "1.0.0",
     "display_name": "Smoothing",
     "license": "Apache-2.0",
-    "license_url": " https://opensource.org/licenses/Apache-2.0",
-    "origin": "RobotecAI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "license_url": "https://opensource.org/licenses/Apache-2.0",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
-    "summary": "Tool gem to smooth movement of the entity",
+    "summary": "A tool for smoothing the entity's movement",
     "canonical_tags": [
         "Gem"
     ],
@@ -18,10 +18,10 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "N/A",
+    "requirements": "",
     "documentation_url": "",
     "dependencies": [],
-    "repo_uri": "",
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "Smoothing"

--- a/Gems/ViewportStreamer/gem.json
+++ b/Gems/ViewportStreamer/gem.json
@@ -4,8 +4,8 @@
     "display_name": "ViewportStreamer",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
-    "origin": "RobotecAI",
-    "origin_url": "https://github.com/RobotecAI/robotec-o3de-tools",
+    "origin": "Robotec.ai",
+    "origin_url": "https://www.robotec.ai",
     "type": "Code",
     "summary": "Application viewport streaming on ROS2 topic",
     "canonical_tags": [
@@ -18,10 +18,12 @@
         ""
     ],
     "icon_path": "preview.png",
-    "requirements": "No requirements",
+    "requirements": "Requires ROS2 Gem",
     "documentation_url": "",
-    "dependencies": ["ROS2"],
-    "repo_uri": "",
+    "dependencies": [
+        "ROS2"
+    ],
+    "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [],
     "engine_api_dependencies": [],
     "restricted": "ViewportStreamer"

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,3 @@
-The default license for Open 3D Engine is the Apache License, Version 2.0 (see LICENSE_APACHE2.TXT). This license applies to the majority of the codebase. Certain Gems may be licensed under the MIT License (see LICENSE_MIT.TXT). For comprehensive licensing details pertaining to individual gems, please consult the `gem.json` file.
+The default license for Open 3D Engine is the Apache License, Version 2.0 (see LICENSE_APACHE2.TXT). This license applies to the majority of the codebase. Certain Gems may be licensed under the MIT License (see LICENSE_MIT.TXT). For comprehensive licensing details pertaining to individual Gems, please consult the `gem.json` files in each folder.
 
 The contributions must be made under the respective licenses.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,3 @@
+The default license for Open 3D Engine is the Apache License, Version 2.0 (see LICENSE_APACHE2.TXT). This license applies to the majority of the codebase. Certain Gems may be licensed under the MIT License (see LICENSE_MIT.TXT). For comprehensive licensing details pertaining to individual gems, please consult the `gem.json` file.
+
+The contributions must be made under the respective licenses.

--- a/LICENSE_APACHE2.TXT
+++ b/LICENSE_APACHE2.TXT
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE_MIT.TXT
+++ b/LICENSE_MIT.TXT
@@ -1,0 +1,7 @@
+Copyright Contributors to the Open 3D Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Note that this is not a "Canonical" part of O3DE - those gems are third-party co
 
 # RobotecRecordingTools
 
-Toolset for joystick-controlled cameras and spline animation tools.
+A toolset for joystick-controlled cameras and spline animation tools.
 
 # SplineTools
 
@@ -120,7 +120,7 @@ It exposes PrefabVariantRequestsBus to Script Canvas or LUA.
 
 # SensorDebug
 
-A tool that allows the adjusted frequency, activate and deactivate sensor during the game mode.
+A tool that allows to adjust frequency, and activate/deactivate sensor during the game mode.
 
 # Smoothing
 


### PR DESCRIPTION
This PR cleans-up the licensing situation of all gems and unifies gem.json information. In particular:
- it unifies _origin_ to _Robotec.ai_ in all `gem.json` files
- it unifies _origin_url_ to the link to our website in all `gem.json` files
- it sets _repo_uri_ to this repository in all `gem.json` files
- it adds description and requirements (only text) if missing in all `gem.json` files
- it adds a _LICENSE_ document in the root of the folder and adds a full text of the Apache 2.0 and MIT licenses

The versions of gems were not updated, as the changes do not influence the code. The changes should be cherry-picked to `2505` branch after the review.