### PR TITLE
Added PointcloudComponentConfig to the gem's API

### DIFF
--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudAsset.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudAsset.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "PointcloudTypeIds.h"
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Asset/AssetSerializer.h>
 #include <AzFramework/Asset/GenericAssetHandler.h>
@@ -20,8 +21,10 @@ namespace Pointcloud
         //! The vertex data for the pointcloud
         struct CloudVertex
         {
+            AZ_TYPE_INFO(CloudVertex, CloudVertexAssetTypeId);
             AZStd::array<float, 3> m_position;
             uint32_t m_color;
+            static void Reflect(AZ::ReflectContext* context);
         };
 
         struct CloudHeader
@@ -37,8 +40,10 @@ namespace Pointcloud
         static constexpr inline const char* Extension = "pointcloud";
         static constexpr inline const char* Group = "Pointcloud";
 
-        AZ_RTTI(PointcloudAsset, "{0190c039-385b-7c8a-9172-31e83c091216}", AZ::Data::AssetData)
+        AZ_RTTI(PointcloudAsset, PointcloudAssetTypeId, AZ::Data::AssetData)
         AZ_CLASS_ALLOCATOR(PointcloudAsset, AZ::SystemAllocator);
+
+        static void Reflect(AZ::ReflectContext* context);
 
         AZStd::vector<CloudVertex> m_data;
     };

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) Contributors to the Open 3D Engine Project.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -14,6 +14,7 @@
 
 namespace Pointcloud
 {
+    //! Configuration for a Pointcloud component.
     class PointcloudComponentConfig final : public AZ::ComponentConfig
     {
     public:
@@ -24,10 +25,17 @@ namespace Pointcloud
 
         static void Reflect(AZ::ReflectContext* context);
 
+        //! Owning entity identifier. This field is set by the PointcloudEditorComponent component during its activation.
         AZ::EntityId m_editorEntityId;
+
+        //! Size of rendered points.
         float m_pointSize = 1.0f;
+
+        //! Runtime handle to the point cloud resource managed by the feature processor.
         PointcloudFeatureProcessorInterface::PointcloudHandle m_pointcloudHandle =
             PointcloudFeatureProcessorInterface::InvalidPointcloudHandle;
+
+        //! Asset reference to the point cloud data to be loaded and rendered.
         AZ::Data::Asset<PointcloudAsset> m_pointcloudAsset = {};
     };
 } // namespace Pointcloud

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -10,13 +10,14 @@
 
 #include "PointcloudAsset.h"
 #include "PointcloudFeatureProcessorInterface.h"
+#include "PointcloudTypeIds.h"
 
 namespace Pointcloud
 {
     class PointcloudComponentConfig final : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(PointcloudComponentConfig, );
+        AZ_RTTI(PointcloudComponentConfig, PointcloudComponentConfigTypeId);
 
         PointcloudComponentConfig() = default;
         ~PointcloudComponentConfig() = default;

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "PointcloudFeatureProcessorInterface.h"
 #include "PointcloudAsset.h"
+#include "PointcloudFeatureProcessorInterface.h"
 
 namespace Pointcloud
 {

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "PointcloudFeatureProcessorInterface.h"
+#include "PointcloudAsset.h"
+
+namespace Pointcloud
+{
+    class PointcloudComponentConfig final : public AZ::ComponentConfig
+    {
+    public:
+        AZ_RTTI(PointcloudComponentConfig, "{3ae848a0-3cd0-439e-bafe-db0270caae47}");
+
+        PointcloudComponentConfig() = default;
+        ~PointcloudComponentConfig() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        AZ::EntityId m_editorEntityId;
+        float m_pointSize = 1.0f;
+        PointcloudFeatureProcessorInterface::PointcloudHandle m_pointcloudHandle =
+            PointcloudFeatureProcessorInterface::InvalidPointcloudHandle;
+        AZ::Data::Asset<PointcloudAsset> m_pointcloudAsset = {};
+    };
+} // namespace Pointcloud

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudComponentConfig.h
@@ -1,3 +1,11 @@
+/*
+* Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
 #pragma once
 
 #include "PointcloudAsset.h"
@@ -8,7 +16,7 @@ namespace Pointcloud
     class PointcloudComponentConfig final : public AZ::ComponentConfig
     {
     public:
-        AZ_RTTI(PointcloudComponentConfig, "{3ae848a0-3cd0-439e-bafe-db0270caae47}");
+        AZ_RTTI(PointcloudComponentConfig, );
 
         PointcloudComponentConfig() = default;
         ~PointcloudComponentConfig() = default;

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
@@ -26,6 +26,10 @@ namespace Pointcloud
     inline constexpr const char* PointcloudEditorComponentTypeId = "{018fba15-560f-78cb-afb4-cf4d00cefc17}";
     inline constexpr const char* PointcloudComponentConfigTypeId = "{3AE848A0-3CD0-439E-BAFE-DB0270CAAE47}";
 
+    // Assets TypeIds
+    inline constexpr const char* PointcloudAssetTypeId = "{0190c039-385b-7c8a-9172-31e83c091216}";
+    inline constexpr const char* CloudVertexAssetTypeId = "{32eac666-ed12-4233-b033-ba2b38a8582c}";
+
     // Interface TypeIds
     inline constexpr const char* PointcloudRequestsTypeId = "{86CA76D8-2225-4C50-86E4-B1C8EFDEA8EF}";
     // component buses

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
@@ -22,16 +22,16 @@ namespace Pointcloud
     inline constexpr const char* PointcloudEditorModuleTypeId = PointcloudModuleTypeId;
 
     // Components TypeIds
-    inline constexpr const char* PointcloudComponentTypeId = "{0190c091-83aa-7c6e-a6da-5efea1f23473}";
-    inline constexpr const char* PointcloudEditorComponentTypeId = "{018fba15-560f-78cb-afb4-cf4d00cefc17}";
+    inline constexpr const char* PointcloudComponentTypeId = "{0190C091-83AA-7C6E-A6DA-5EFEA1F23473}";
+    inline constexpr const char* PointcloudEditorComponentTypeId = "{018FBA15-560F-78CB-AFB4-CF4D00CEFC17}";
     inline constexpr const char* PointcloudComponentConfigTypeId = "{3AE848A0-3CD0-439E-BAFE-DB0270CAAE47}";
 
     // Assets TypeIds
-    inline constexpr const char* PointcloudAssetTypeId = "{0190c039-385b-7c8a-9172-31e83c091216}";
-    inline constexpr const char* CloudVertexAssetTypeId = "{32eac666-ed12-4233-b033-ba2b38a8582c}";
+    inline constexpr const char* PointcloudAssetTypeId = "{0190C039-385B-7C8A-9172-31E83C091216}";
+    inline constexpr const char* CloudVertexAssetTypeId = "{32EAC666-ED12-4233-B033-BA2B38A8582C}";
 
     // Interface TypeIds
     inline constexpr const char* PointcloudRequestsTypeId = "{86CA76D8-2225-4C50-86E4-B1C8EFDEA8EF}";
     // component buses
-    inline constexpr const char* PointCloudRequestsTypeId = "{5985443b-feab-444f-a633-4b2a8142c560}";
+    inline constexpr const char* PointCloudRequestsTypeId = "{5985443B-FEAB-444F-A633-4B2A8142C560}";
 } // namespace Pointcloud

--- a/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
+++ b/Gems/Pointcloud/Code/Include/Pointcloud/PointcloudTypeIds.h
@@ -24,6 +24,7 @@ namespace Pointcloud
     // Components TypeIds
     inline constexpr const char* PointcloudComponentTypeId = "{0190c091-83aa-7c6e-a6da-5efea1f23473}";
     inline constexpr const char* PointcloudEditorComponentTypeId = "{018fba15-560f-78cb-afb4-cf4d00cefc17}";
+    inline constexpr const char* PointcloudComponentConfigTypeId = "{3AE848A0-3CD0-439E-BAFE-DB0270CAAE47}";
 
     // Interface TypeIds
     inline constexpr const char* PointcloudRequestsTypeId = "{86CA76D8-2225-4C50-86E4-B1C8EFDEA8EF}";

--- a/Gems/Pointcloud/Code/Source/Clients/PointcloudAsset.cpp
+++ b/Gems/Pointcloud/Code/Source/Clients/PointcloudAsset.cpp
@@ -6,10 +6,30 @@
  *
  */
 
+#include <AzCore/Component/ComponentBus.h>
 #include <Pointcloud/PointcloudAsset.h>
 
 namespace Pointcloud
 {
+    void PointcloudAsset::CloudVertex::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PointcloudAsset::CloudVertex>()
+                ->Version(0)
+                ->Field("m_position", &PointcloudAsset::CloudVertex::m_position)
+                ->Field("m_color", &PointcloudAsset::CloudVertex::m_color);
+        }
+    }
+
+    void PointcloudAsset::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PointcloudAsset, AZ::Data::AssetData>()->Version(0)->Field("m_data", &PointcloudAsset::m_data);
+        }
+    }
+
     PointcloudAssetHandler::PointcloudAssetHandler()
         : AzFramework::GenericAssetHandler<PointcloudAsset>(
               PointcloudAsset::DisplayName, PointcloudAsset::Group, PointcloudAsset::Extension)

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudAssetBuilderSystemComponent.cpp
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudAssetBuilderSystemComponent.cpp
@@ -11,6 +11,7 @@ namespace Pointcloud
 
     void PointcloudAssetBuilderSystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        PointcloudAsset::Reflect(context);
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<PointcloudAssetBuilderSystemComponent, AZ::Component>()->Version(0)->Attribute(

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudComponentController.h
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudComponentController.h
@@ -12,9 +12,9 @@
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Math/Aabb.h>
+#include <Pointcloud/PointcloudComponentConfig.h>
 #include <Pointcloud/PointcloudConfigurationBus.h>
 #include <Pointcloud/PointcloudFeatureProcessorInterface.h>
-#include <Pointcloud/PointcloudComponentConfig.h>
 
 namespace Pointcloud
 {

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudComponentController.h
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudComponentController.h
@@ -14,26 +14,10 @@
 #include <AzCore/Math/Aabb.h>
 #include <Pointcloud/PointcloudConfigurationBus.h>
 #include <Pointcloud/PointcloudFeatureProcessorInterface.h>
+#include <Pointcloud/PointcloudComponentConfig.h>
 
 namespace Pointcloud
 {
-    class PointcloudComponentConfig final : public AZ::ComponentConfig
-    {
-    public:
-        AZ_RTTI(PointcloudComponentConfig, "{3ae848a0-3cd0-439e-bafe-db0270caae47}");
-
-        PointcloudComponentConfig() = default;
-        ~PointcloudComponentConfig() = default;
-
-        static void Reflect(AZ::ReflectContext* context);
-
-        AZ::EntityId m_editorEntityId;
-        float m_pointSize = 1.0f;
-        PointcloudFeatureProcessorInterface::PointcloudHandle m_pointcloudHandle =
-            PointcloudFeatureProcessorInterface::InvalidPointcloudHandle;
-        AZ::Data::Asset<PointcloudAsset> m_pointcloudAsset = {};
-    };
-
     class PointcloudComponentController
         : public PointcloudConfigurationBus::Handler
         , private AZ::TransformNotificationBus::Handler

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
@@ -34,6 +34,17 @@ namespace Pointcloud
         }
     }
 
+    PointcloudEditorComponent::PointcloudEditorComponent(const PointcloudComponentConfig& configuration)
+        : PointcloudEditorComponentBase(configuration)
+    {
+    }
+
+    bool PointcloudEditorComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
+    {
+        m_controller.SetConfiguration(*static_cast<const PointcloudComponentConfig*>(baseConfig));
+        return true;
+    }
+
     void PointcloudEditorComponent::Activate()
     {
         PointcloudEditorComponentBase::Activate();

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.cpp
@@ -41,7 +41,13 @@ namespace Pointcloud
 
     bool PointcloudEditorComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
     {
-        m_controller.SetConfiguration(*static_cast<const PointcloudComponentConfig*>(baseConfig));
+        const PointcloudComponentConfig* config = azrtti_cast<const PointcloudComponentConfig*>(baseConfig);
+        if (!config)
+        {
+            AZ_Error("PointcloudEditorComponent", false, "Failed to set new configuration.");
+            return false;
+        }
+        m_controller.SetConfiguration(*config);
         return true;
     }
 

--- a/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.h
+++ b/Gems/Pointcloud/Code/Source/Tools/Components/PointcloudEditorComponent.h
@@ -45,6 +45,9 @@ namespace Pointcloud
         AZ::Aabb GetWorldBounds() const override;
         AZ::Aabb GetLocalBounds() const override;
 
+        // AZ::Component overrides ...
+        bool ReadInConfig(const AZ::ComponentConfig* baseConfig) override;
+
         // AzToolsFramework::EditorComponentSelectionRequestsBus overrides ...
         AZ::Aabb GetEditorSelectionBoundsViewport(const AzFramework::ViewportInfo& viewportInfo) override;
         bool EditorSelectionIntersectRayViewport(

--- a/Gems/Pointcloud/Code/pointcloud_api_files.cmake
+++ b/Gems/Pointcloud/Code/pointcloud_api_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
-        Include/Pointcloud/PointcloudTypeIds.h
+    Include/Pointcloud/PointcloudTypeIds.h
     Include/Pointcloud/PointcloudFeatureProcessorInterface.h
+    Include/Pointcloud/PointcloudComponentConfig.h
 )

--- a/Gems/Pointcloud/gem.json
+++ b/Gems/Pointcloud/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "Pointcloud",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "display_name": "Pointcloud",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

This PR moves the `PointcloudComponentConfig` class to the API target of this gem. This allows the object to be created from other gems without linking to other Pointcloud targets. The AZ::Component::ReadInConfig function has also been implemented inside the editor component for the same reason as moving the config to the API: to configure Pointcloud from other gems.

---

## How was this PR tested?

The Pointcloud Editor component was created in another gem, configured, saved in prefab and tested in the O3DE Editor.

---

## Screenshots / Logs / Supporting Evidence (if applicable)

N/A

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [X] Code changes are well-documented
- [ ] Tests have been added or updated
- [X] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
