### PR TITLE
fix(WheelAnimTool): normalize quaternion to avoid scaling issues

### DIFF
--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
@@ -345,8 +345,9 @@ namespace WheelAnimTool
             const float wheelAngle = (wheelSpeed / m_wheelRadius) * deltaTime; // angle in radians
             const AZ::Quaternion wheelRotationIncrement = AZ::Quaternion::CreateFromAxisAngle(m_wheelAxis, wheelAngle);
             const AZ::Quaternion newWheelRotation = wheelTransform.GetRotation() * wheelRotationIncrement;
+            const AZ::Quaternion newWheelRotationNormalized = newWheelRotation.GetNormalized();
 
-            AZ::TransformBus::Event(m_wheelEntities[i], &AZ::TransformInterface::SetWorldRotationQuaternion, newWheelRotation);
+            AZ::TransformBus::Event(m_wheelEntities[i], &AZ::TransformInterface::SetWorldRotationQuaternion, newWheelRotationNormalized);
             if (m_debugDraw)
             {
                 using namespace DebugDraw;

--- a/Gems/WheelAnimTool/gem.json
+++ b/Gems/WheelAnimTool/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "WheelAnimTool",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "WheelAnimTool",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

Fix the wheel scaling issue caused by unnormalized quaternions, which led to gradual scaling errors over time.

Normalizing the quaternion just before announcing it to the TransformBus may be the safest, but could overshadow a bug deeper down in the code. Please let me know at which point should we normalize it. Thanks.

---

## How was this PR tested?

Manual tests including preparing a fast failure mode code for finding the cause of the bug.

```cpp
            const AZ::Quaternion wheelRotationIncrement = AZ::Quaternion::CreateFromAxisAngle(m_wheelAxis, wheelAngle);
            AZ::Quaternion newWheelRotation = wheelTransform.GetRotation() * wheelRotationIncrement;
            for (uint j = 0; j < 100000; ++j)
            {
                newWheelRotation = newWheelRotation * wheelRotationIncrement;
            }

            AZ::TransformBus::Event(m_wheelEntities[i], &AZ::TransformInterface::SetWorldRotationQuaternion, newWheelRotation);
 ```
---

## Screenshots / Logs / Supporting Evidence (if applicable)


---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [x] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines

---

Thanks @jhanca-robotecai for suggesting the root cause. 
