### PR TITLE
Cherry-pick of the [ROS2PoseControl] Add snap to ground with tag option (#145)

### DIFF
--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControl.cpp
@@ -528,9 +528,9 @@ namespace ROS2PoseControl
 
         AZ::Transform modifiedTransform = m_configuration.m_lockZAxis ? RemoveTilt(transform) : transform;
 
-        if (!m_configuration.m_startOffsetTag.empty())
+        if (!m_configuration.m_offsetTag.empty())
         {
-            auto startOffsetTransform = GetOffsetTransform(m_configuration.m_startOffsetTag);
+            auto startOffsetTransform = GetOffsetTransform(m_configuration.m_offsetTag);
             if (startOffsetTransform.has_value())
             {
                 modifiedTransform = startOffsetTransform.value() * modifiedTransform;
@@ -583,6 +583,19 @@ namespace ROS2PoseControl
         request.m_start = location;
         request.m_direction = gravityDirection;
         request.m_distance = maxDistance;
+
+        if (m_configuration.m_useClampTag)
+        {
+            AZStd::string query = m_configuration.m_clampTag;
+            request.m_filterCallback = [&query](const AzPhysics::SimulatedBody* body, [[maybe_unused]] const Physics::Shape* shape)
+            {
+                const auto entityId = body->GetEntityId();
+                LmbrCentral::Tags tags;
+                LmbrCentral::TagComponentRequestBus::EventResult(tags, entityId, &LmbrCentral::TagComponentRequests::GetTags);
+                return (tags.contains(AZ::Crc32(query))) ? AzPhysics::SceneQuery::QueryHitType::Block
+                                                         : AzPhysics::SceneQuery::QueryHitType::None;
+            };
+        }
 
         AzPhysics::SceneQueryHits result = sceneInterface->QueryScene(sceneHandle, &request);
 

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.cpp
@@ -31,7 +31,17 @@ namespace ROS2PoseControl
 
     AZ::Crc32 ROS2PoseControlConfiguration::isUseTagOffset() const
     {
-        return m_useTagOffset ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+        return m_useOffsetTag ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+    }
+
+    AZ::Crc32 ROS2PoseControlConfiguration::isUseClamp() const
+    {
+        return m_clampToGround ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
+    }
+
+    AZ::Crc32 ROS2PoseControlConfiguration::isUseTagClamp() const
+    {
+        return m_useClampTag && m_clampToGround ? AZ::Edit::PropertyVisibility::Show : AZ::Edit::PropertyVisibility::Hide;
     }
 
     void ROS2PoseControlConfiguration::Reflect(AZ::ReflectContext* context)
@@ -46,9 +56,11 @@ namespace ROS2PoseControl
                 ->Field("m_targetFrame", &ROS2PoseControlConfiguration::m_targetFrame)
                 ->Field("m_referenceFrame", &ROS2PoseControlConfiguration::m_referenceFrame)
                 ->Field("lockZAxis", &ROS2PoseControlConfiguration::m_lockZAxis)
-                ->Field("useTagOffset", &ROS2PoseControlConfiguration::m_useTagOffset)
-                ->Field("startOffsetTag", &ROS2PoseControlConfiguration::m_startOffsetTag)
+                ->Field("useTagOffset", &ROS2PoseControlConfiguration::m_useOffsetTag)
+                ->Field("startOffsetTag", &ROS2PoseControlConfiguration::m_offsetTag)
                 ->Field("m_clampToGround", &ROS2PoseControlConfiguration::m_clampToGround)
+                ->Field("useTagClamp", &ROS2PoseControlConfiguration::m_useClampTag)
+                ->Field("clampTag", &ROS2PoseControlConfiguration::m_clampTag)
                 ->Field("m_groundOffset", &ROS2PoseControlConfiguration::m_groundOffset)
                 ->Field("useWGS", &ROS2PoseControlConfiguration::m_useWGS);
 
@@ -99,19 +111,32 @@ namespace ROS2PoseControl
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ROS2PoseControlConfiguration::m_lockZAxis, "Lock Z Axis", "Lock Z axis")
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ROS2PoseControlConfiguration::m_useTagOffset,
+                        &ROS2PoseControlConfiguration::m_useOffsetTag,
                         "Use Tag Offset",
                         "Use a tag that will be used to set the start offset for the entity.")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
-                        &ROS2PoseControlConfiguration::m_startOffsetTag,
+                        &ROS2PoseControlConfiguration::m_offsetTag,
                         "Start Offset Tag",
                         "Tag that will be used to set the start offset for the entity.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isUseTagOffset)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &ROS2PoseControlConfiguration::m_clampToGround, "Clamp to Ground", "Clamp to ground")
                     ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2PoseControlConfiguration::m_useClampTag,
+                        "Use Tag Clamp",
+                        "Use a tag that will be used to set the ground for the clamp for the entity.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isUseClamp)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ROS2PoseControlConfiguration::m_clampTag,
+                        "Clamp Tag",
+                        "Tag that will be used to clamp the entity to the ground.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ROS2PoseControlConfiguration::isUseTagClamp)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ROS2PoseControlConfiguration::m_groundOffset,

--- a/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.h
+++ b/Gems/ROS2PoseControl/Code/Source/Clients/ROS2PoseControlConfiguration.h
@@ -36,6 +36,10 @@ namespace ROS2PoseControl
 
         AZ::Crc32 isUseTagOffset() const;
 
+        AZ::Crc32 isUseTagClamp() const;
+
+        AZ::Crc32 isUseClamp() const;
+
         TrackingMode m_tracking_mode = TrackingMode::PoseMessages;
         ROS2::TopicConfiguration m_poseTopicConfiguration;
 
@@ -46,9 +50,11 @@ namespace ROS2PoseControl
 
         bool m_clampToGround = false;
         float m_groundOffset = 0.0f;
+        bool m_useClampTag = false;
+        AZStd::string m_clampTag;
 
-        bool m_useTagOffset = false;
-        AZStd::string m_startOffsetTag;
+        bool m_useOffsetTag = false;
+        AZStd::string m_offsetTag;
 
         bool m_useWGS = false;
 

--- a/Gems/ROS2PoseControl/gem.json
+++ b/Gems/ROS2PoseControl/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ROS2PoseControl",
-    "version": "3.0.1",
+    "version": "3.1.1",
     "display_name": "ROS2PoseControl",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?
As in the title. #145 

---

## How was this PR tested?

1. Created a primitive collider with the tag.
2. Created another primitive collider with same width and length as the previous one, but the height was slightly bigger.
3. Sent a `geometry_msgs/msg/PoseStamped` with coordinates inside the colliders, checking to which of them the `Shader Ball` mesh with `ROS2PoseControl` will clamp.[

---

## Screenshots / Logs / Supporting Evidence (if applicable)

NA

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [X] Code changes are well-documented
- [ ] Tests have been added or updated
- [X] The code is formatted according to the project's style guide
- [ ] The version number has been updated according to the contributing guidelines
