### PR TITLE
Add o3de-sdk to gem.json files

### DIFF
--- a/Gems/Pointcloud/gem.json
+++ b/Gems/Pointcloud/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "Pointcloud",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "display_name": "Pointcloud",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -26,7 +26,8 @@
     ],
     "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [
-        "o3de>=2.4.0"
+        "o3de>=2.4.0",
+        "o3de-sdk>=2.4.0"
     ],
     "engine_api_dependencies": [],
     "restricted": "Pointcloud"

--- a/Gems/RobotecSplineTools/gem.json
+++ b/Gems/RobotecSplineTools/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "SplineTools",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "display_name": "SplineTools",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",
@@ -26,7 +26,8 @@
     ],
     "repo_uri": "https://github.com/RobotecAI/robotec-o3de-tools",
     "compatible_engines": [
-        "o3de>=2.4.0"
+        "o3de>=2.4.0",
+        "o3de-sdk>=2.4.0"
     ],
     "engine_api_dependencies": [],
     "restricted": "SplineTools"


### PR DESCRIPTION
## What does this PR do?

Update gem.json files to include o3de-sdk to remove warnings such as: 
```
  SplineTools is incompatible because: o3de-sdk 2.4.1 does not match any
  version specifiers in the list of compatible engines: ['o3de>=2.4.0']
```

## How was this PR tested?

The code was built against SDK

---

## Screenshots / Logs / Supporting Evidence (if applicable)

_Add screenshots, terminal logs, or relevant links to builds/tests as needed._

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [ ] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
