### PR TITLE
Scale pointcloud points with distance

### DIFF
--- a/Gems/Pointcloud/Assets/Shaders/Pointclouds/Pointclouds.azsl
+++ b/Gems/Pointcloud/Assets/Shaders/Pointclouds/Pointclouds.azsl
@@ -30,6 +30,24 @@ struct VSOutput
     [[vk::builtin("PointSize")]] float PointSize : PSIZE;
 };
 
+float LinearizeDepth(const float depth)
+{
+    return ViewSrg::GetFarZTimesNearZ() / (ViewSrg::GetFarZ() - depth * ViewSrg::GetFarZMinusNearZ());
+}
+
+float GetPointSize(float4 position)
+{
+    // Arbitrary scale factor to adjust point size falloff with depth.
+    // Value of 10.0 results in points with m_pointSize of 1.0 appearing as if they are 1cm in diameter.
+    const float depthScale = 10.0;
+
+    float depth = position.z / position.w;
+    float linearDepth = LinearizeDepth(depth) / depthScale;
+    float pointSize = PerDrawSrg::m_pointSize / linearDepth;
+
+    return pointSize;
+}
+
 VSOutput MainVS(VSInput IN)
 {
     VSOutput OUT;
@@ -37,7 +55,7 @@ VSOutput MainVS(VSInput IN)
     const float4 pos2 = mul(PerDrawSrg::m_modelMatrix, pos);
     OUT.m_position = mul(ViewSrg::m_viewProjectionMatrix, pos2);
     OUT.m_color = IN.m_color;
-    OUT.PointSize = PerDrawSrg::m_pointSize;
+    OUT.PointSize = GetPointSize(OUT.m_position);
     return OUT;
 };
 

--- a/Gems/Pointcloud/gem.json
+++ b/Gems/Pointcloud/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "Pointcloud",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "display_name": "Pointcloud",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

This PR makes size of Pointcloud points rendered by PointCloud Gem depend on distance. 
Previously if pointSize is set to 1.0 all points will be rendered with the same size, this causes groups of points that are further to combine into a plane with z fighting while zooming close into groups of points made them dissapear.

After this change size of rendered points depends linearly on distance. This means that dense point clouds can also be seen from small distance.


## How was this PR tested?

I imported an example pointcloud and changed camera position to observe different pointcloud size depending of distance. 

## Screenshots / Logs / Supporting Evidence (if applicable)


| Title | Previously | Now |
| -- | -- | -- |
| Look into the distance | <img width="609" height="719" alt="Screenshot from 2025-12-01 11-17-11" src="https://github.com/user-attachments/assets/855ff701-68c0-4d86-b84e-213fd9287c4c" /> |  <img width="609" height="719" alt="image" src="https://github.com/user-attachments/assets/389b9b9c-a3d2-42bb-b32e-095463b42c85" /> |
| Zoom close | <img width="609" height="719" alt="Screenshot from 2025-12-01 11-18-02" src="https://github.com/user-attachments/assets/cacd3416-a6c5-45f5-b6f3-46efa8effcac" /> |  <img width="609" height="719" alt="Screenshot from 2025-12-01 11-20-39" src="https://github.com/user-attachments/assets/17c2dc06-a991-4de3-9055-c83f555073a6" /> |

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [x] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [x] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
