### PR TITLE
RobotecSplineTools: add rclcpp dependency

### DIFF
--- a/Gems/RobotecSplineTools/Code/CMakeLists.txt
+++ b/Gems/RobotecSplineTools/Code/CMakeLists.txt
@@ -57,6 +57,8 @@ ly_add_target(
             Gem::LevelGeoreferencing.API
 )
 
+target_depends_on_ros2_packages(${gem_name}.Private.Object rclcpp  nav_msgs)
+
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(
     NAME ${gem_name} ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}

--- a/Gems/RobotecSplineTools/gem.json
+++ b/Gems/RobotecSplineTools/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "SplineTools",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "display_name": "SplineTools",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

We use ROS 2 in the gem, but we do not explicitly link to `rclcpp` and `nav_msgs`. The linking is done via ROS 2 Gem. However, it does not work in some cases, resulting in an error which is hard to decrypt:
```
CMake Error in /workspace/project/perception-simulation/gems/robotec-o3de-tools/Gems/RobotecSplineTools/Code/CMakeLists.txt:
4818
17:01:03
  Error evaluating generator expression:
4819
17:01:03
    $<TARGET_PROPERTY:fastcdr,TYPE>
4820
17:01:03
  Target "fastcdr" not found.
```

---

## How was this PR tested?

Successfully builds.

---

## Screenshots / Logs / Supporting Evidence (if applicable)

_Add screenshots, terminal logs, or relevant links to builds/tests as needed._

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [ ] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [ ] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
