### PR TITLE
Removed edge constraints in FreeFlying mode

### DIFF
--- a/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
+++ b/Gems/RobotecSpectatorCamera/Code/Source/SpectatorCamera/SpectatorCameraComponent.cpp
@@ -162,7 +162,7 @@ namespace RobotecSpectatorCamera
             }
         }
 
-        if ((m_isRightMouseButtonPressed || m_configuration.m_cameraMode == CameraMode::FreeFlying) &&
+        if (m_configuration.m_cameraMode == CameraMode::ThirdPerson && m_isRightMouseButtonPressed &&
             (channelId == AzFramework::InputDeviceMouse::Movement::X || channelId == AzFramework::InputDeviceMouse::Movement::Y))
         {
             if (m_ignoreNextMovement)
@@ -177,7 +177,7 @@ namespace RobotecSpectatorCamera
 
             if (m_centerTheCursor)
             {
-                const auto center = AZ::Vector2(0.5f, 0.5f);
+                const AZ::Vector2 center(0.5f, 0.5f);
 
                 // Recenter the cursor to avoid edge constraints
                 AzFramework::InputSystemCursorRequestBus::Event(
@@ -189,6 +189,29 @@ namespace RobotecSpectatorCamera
             else
             {
                 m_lastMousePosition = currentMousePosition;
+            }
+
+            RotateCameraOnMouse(mouseDelta);
+        }
+
+        if (m_configuration.m_cameraMode == CameraMode::FreeFlying &&
+            (channelId == AzFramework::InputDeviceMouse::Movement::X || channelId == AzFramework::InputDeviceMouse::Movement::Y))
+        {
+            // Scale is needed because the mouseDelta for ThirdPerson mode uses a normalized cursor position, resulting in small differences
+            // between events. However, the FreeFlying mode uses the value directly from the input channel, which appears to be in pixels.
+            // Therefore, the calculated mouse delta is much bigger. Without this parameter, the camera rotation speed in FreeFlying mode is
+            // so high that the spectator camera becomes almost useless. The value of the scale was chosen arbitrarily.
+            constexpr float mouseDeltaScale = 0.002f;
+
+            AZ::Vector2 mouseDelta = AZ::Vector2::CreateZero();
+
+            if (channelId == AzFramework::InputDeviceMouse::Movement::X)
+            {
+                mouseDelta.SetX(inputChannel.GetValue() * mouseDeltaScale);
+            }
+            else
+            {
+                mouseDelta.SetY(inputChannel.GetValue() * mouseDeltaScale);
             }
 
             RotateCameraOnMouse(mouseDelta);

--- a/Gems/RobotecSpectatorCamera/gem.json
+++ b/Gems/RobotecSpectatorCamera/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "RobotecSpectatorCamera",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "display_name": "RobotecSpectatorCamera",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",


### PR DESCRIPTION
## What does this PR do?

This PR removes the edge constraints in FreeFlying mode. Without this PR, the camera rotation in FreeFlying mode is limited by the screen size. If the cursor reaches the screen edge, the camera becomes blocked in that plane. This is due to the use of the `GetSystemCursorPositionNormalized` function, which returns the cursor position in normalized screen space. This is useful for the ThirdPerson mode, but limits the FreeFlying mode. With this PR, the camera can rotate freely along the X and Y axes without limitations, similar to the O3DE `Fly Input Camera`.

---

## How was this PR tested?

By using RobotecSpectatorCamera in both ThirdPerson and FreeFlying modes.

---

## Screenshots / Logs / Supporting Evidence (if applicable)

NA

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [X] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [X] The code is formatted according to the project's style guide
- [X] The version number has been updated according to the contributing guidelines
