### PR TITLE
[2605] ViewportStreamer in o3de 2605

### DIFF
--- a/Gems/ViewportStreamer/Code/CMakeLists.txt
+++ b/Gems/ViewportStreamer/Code/CMakeLists.txt
@@ -47,6 +47,8 @@ ly_add_target(
             Include
             Source
     BUILD_DEPENDENCIES
+        PRIVATE
+            Gem::Atom_Feature_Common.Public
         PUBLIC
             AZ::AzCore
             AZ::AzFramework

--- a/Gems/ViewportStreamer/Code/Source/Clients/ViewportStreamerSystemComponent.cpp
+++ b/Gems/ViewportStreamer/Code/Source/Clients/ViewportStreamerSystemComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
+#include <ROS2/Clock/ROS2ClockRequestBus.h>
 #include <ROS2/Communication/QoS.h>
 #include <ROS2/ROS2Bus.h>
 #include <ViewportStreamer/ViewportStreamerTypeIds.h>
@@ -171,7 +172,7 @@ namespace ViewportStreamer
                 auto passHierarchy = GetPassHierarchyFromRenderPipeline(pipeline);
 
                 std_msgs::msg::Header messageHeader;
-                messageHeader.stamp = ROS2::ROS2Interface::Get()->GetROSTimestamp();
+                messageHeader.stamp = ROS2::ROS2ClockInterface::Get()->GetROSTimestamp();
                 messageHeader.frame_id = m_frameName.c_str();
 
                 RequestMessagePublication(passHierarchy, messageHeader);

--- a/Gems/ViewportStreamer/gem.json
+++ b/Gems/ViewportStreamer/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ViewportStreamer",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "display_name": "ViewportStreamer",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Note that this is not a "Canonical" part of O3DE - those gems are third-party co
 | [**ROS2ScriptIntegration**](#ros2scriptintegration)         | compatible    |
 | [**SensorDebug**](#sensordebug)                             | not verified  |
 | [**Smoothing**](#smoothing)                                 | not verified  |
-| [**ViewportStreamer**](#viewportstreamer)                   | not verified  |
+| [**ViewportStreamer**](#viewportstreamer)                   | compatible    |
 | [**WheelAnimTool**](#wheelanimtool)                         | not verified  |
 
 # CsvSpawner


### PR DESCRIPTION
## What does this PR do?

Support `ViewportStreamer` in o3de-2605

---

## How was this PR tested?

Example project. 
- Checked that ROS 2 topic publishes some data on `/viewport`
- preview in `rqt_image_view`

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [ ] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [x] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
