### PR TITLE
[2605] WheelAnimTool: remove Eigen dependency + fix rotation

### DIFF
--- a/Gems/WheelAnimTool/Code/CMakeLists.txt
+++ b/Gems/WheelAnimTool/Code/CMakeLists.txt
@@ -31,7 +31,6 @@ if(NOT PAL_TRAIT_WHEELANIMTOOL_SUPPORTED)
     return()
 endif()
 
-find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 # The ${gem_name}.API target declares the common interface that users of this gem should depend on in their targets
 ly_add_target(
@@ -69,7 +68,6 @@ ly_add_target(
             Gem::Atom_RPI.Public
 
 )
-target_link_libraries(${gem_name}.Private.Object PRIVATE Eigen3::Eigen)
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
 ly_add_target(

--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
@@ -18,25 +18,9 @@
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <Eigen/Dense>
+#include <AzCore/Math/VectorN.h>
 namespace WheelAnimTool
 {
-    namespace EigenO3DE
-    {
-        Eigen::Vector2d ToEigen(const AZ::Vector2& vec)
-        {
-            return Eigen::Vector2d(vec.GetX(), vec.GetY());
-        }
-        Eigen::Vector3d ToEigen(const AZ::Vector3& vec)
-        {
-            return Eigen::Vector3d(vec.GetX(), vec.GetY(), vec.GetZ());
-        }
-
-        AZ::Vector3 ToO3DE(const Eigen::Vector3d& vec)
-        {
-            return AZ::Vector3(vec.x(), vec.y(), vec.z());
-        }
-    } // namespace EigenO3DE
 
     namespace DebugDraw
     {
@@ -176,17 +160,17 @@ namespace WheelAnimTool
     void WheelAnimComponent::Deactivate()
     {
         AZ::TickBus::Handler::BusDisconnect();
-        m_jacobian = Eigen::MatrixXd();
+        m_jacobian = AZ::MatrixMxN();
         m_wheelAxisSign.clear();
     }
 
     //! \brief Create a row of the Jacobian matrix for a mecanum wheel.
     //! \param rollerDirection The direction of the rollers on the wheel, normalized.
     //! \param wheelPosition The position of the wheel in 3D space.
-    Eigen::Vector3d CreateMecanumJacobianRow(Eigen::Vector2d rollerDirection, const Eigen::Vector3d& wheelPosition)
+    AZ::Vector3 CreateMecanumJacobianRow(AZ::Vector2 rollerDirection, const AZ::Vector3& wheelPosition)
     {
         // Normalize roller direction
-        rollerDirection.normalize();
+        rollerDirection.NormalizeSafe();
 
         // I've tried to recreate the jacobian row based on the roller direction and wheel position.
         // The model is based on equation 29 from paper :
@@ -203,17 +187,14 @@ namespace WheelAnimTool
         //  - \omega is the angular velocity of the robot, r is the wheel radius,
         //  - L_x is robot track and L_y is robot wheelbase.
 
-        const float Lx = abs(wheelPosition.x()) * 2.f; // Assuming wheelPosition.x() is the half of track width
-        const float Ly = abs(wheelPosition.y()) * 2.f; // Assuming wheelPosition.y() is the half of wheelbase
-        const float sign = (wheelPosition.y() > 0.f) ? -1.f : 1.f; // Sign based if robot wheel is on the left or right side
+        const float Lx = abs(wheelPosition.GetX()) * 2.f; // Assuming wheelPosition.x() is the half of track width
+        const float Ly = abs(wheelPosition.GetY()) * 2.f; // Assuming wheelPosition.y() is the half of wheelbase
+        const float sign = (wheelPosition.GetY() > 0.f) ? -1.f : 1.f; // Sign based if robot wheel is on the left or right side
 
-        // Create jacobian row
-        Eigen::Vector3d jacobianRow;
-        jacobianRow << rollerDirection.x(), rollerDirection.y(), sign * (Lx + Ly) / 2.f;
-        return jacobianRow;
+        return AZ::Vector3(rollerDirection.GetX(), rollerDirection.GetY(), sign * (Lx + Ly) / 2.f);
     }
 
-    Eigen::Vector3d CreateDifferentialJacobianRow(const Eigen::Vector3d& wheelPosition)
+    AZ::Vector3 CreateDifferentialJacobianRow(const AZ::Vector3& wheelPosition)
     {
         // For differential drive, the model for wheel speed is simpler:
         // \omega_1 = \frac{1}{r} (v_x + \frac{L_x}{2} * \omega)
@@ -224,12 +205,10 @@ namespace WheelAnimTool
         //  - \omega is the angular velocity of the robot, r is the wheel radius,
         //  - L_x is robot track.
 
-        const float Lx = abs(wheelPosition.x()) * 2.f; // Assuming wheelPosition.x() is the half of track width
-        const float sign = (wheelPosition.y() > 0.f) ? -1.f : 1.f; // Sign based if robot wheel is on the left or right side
+        const float Lx = abs(wheelPosition.GetX()) * 2.f; // Assuming wheelPosition.x() is the half of track width
+        const float sign = (wheelPosition.GetY() > 0.f) ? -1.f : 1.f; // Sign based if robot wheel is on the left or right side
 
-        Eigen::Vector3d jacobianRow;
-        jacobianRow << 1.0, 0.0, sign * (Lx / 2.f); // we assume the robot X axis is forward, Y axis is left, and Z axis is up
-        return jacobianRow;
+        return AZ::Vector3(1.0f, 0.0f, sign * (Lx / 2.f)); // we assume the robot X axis is forward, Y axis is left, and Z axis is up
     }
 
     bool WheelAnimComponent::InitJacobian()
@@ -243,8 +222,8 @@ namespace WheelAnimTool
             return false;
         }
         // compute geometrical center of the wheels
-        Eigen::Vector3d meanWheelPosition = Eigen::Vector3d::Zero();
-        Eigen::Matrix<double, Eigen::Dynamic, 3> wheelPositions(numWheels, 3);
+        AZ::Vector3 meanWheelPosition = AZ::Vector3::CreateZero();
+        AZStd::vector<AZ::Vector3> wheelPositions(numWheels);
 
         AZ_Assert(GetEntity()->GetTransform(), "No transform interface");
         const AZ::Transform worldTransform = GetEntity()->GetTransform()->GetWorldTM();
@@ -256,26 +235,26 @@ namespace WheelAnimTool
             AZ::TransformBus::EventResult(wheelPos, wheelEntity, &AZ::TransformInterface::GetWorldTranslation);
             // transform wheel position to local space
             const AZ::Vector3 wheelPosLoc = worldTransformInv.TransformPoint(wheelPos);
-            meanWheelPosition += EigenO3DE::ToEigen(wheelPosLoc);
-            wheelPositions.row(i) = EigenO3DE::ToEigen(wheelPosLoc);
+            meanWheelPosition += wheelPosLoc;
+            wheelPositions[i] = wheelPosLoc;
         }
-        meanWheelPosition /= numWheels;
+        meanWheelPosition /= static_cast<float>(numWheels);
 
         // calculate location w.r.t the mean wheel position
         for (int i = 0; i < numWheels; ++i)
         {
-            wheelPositions.row(i) -= meanWheelPosition;
+            wheelPositions[i] -= meanWheelPosition;
         }
 
-        if (m_jacobian.rows() != numWheels)
+        if (m_jacobian.GetRowCount() != numWheels)
         {
             // update jacobian matrix size
-            m_jacobian = Eigen::MatrixXd(numWheels, 3); // we transform 3D speed to 1D speed of wheel
+            m_jacobian = AZ::MatrixMxN(numWheels, 3); // we transform 3D speed to 1D speed of wheel
             m_wheelAxisSign.resize(numWheels);
             const AZ::Vector3 robotAxisInWorld = worldTransform.TransformVector(m_wheelAxis);
             for (int i = 0; i < numWheels; ++i)
             {
-                const Eigen::Vector3d wheelPosition = wheelPositions.row(i);
+                const AZ::Vector3& wheelPosition = wheelPositions[i];
 
                 // Detect mirrored wheel meshes (e.g. 180 deg X flip reusing the same mesh for both sides).
                 // If the wheel's spin axis opposes the robot body's spin axis, the rotation angle must be
@@ -285,19 +264,25 @@ namespace WheelAnimTool
                 const AZ::Vector3 wheelAxisInWorld = wheelTM.TransformVector(m_wheelAxis);
                 m_wheelAxisSign[i] = (robotAxisInWorld.Dot(wheelAxisInWorld) >= 0.f) ? 1.f : -1.f;
 
+                auto setRow = [&](const AZ::Vector3& row)
+                {
+                    m_jacobian.SetElement(i, 0, row.GetX());
+                    m_jacobian.SetElement(i, 1, row.GetY());
+                    m_jacobian.SetElement(i, 2, row.GetZ());
+                };
+
                 if (m_animationType == AnimationType::Mecanum)
                 {
-                    const Eigen::Vector2d rollerDirection = EigenO3DE::ToEigen(m_rollerDirections[i]);
-                    m_jacobian.row(i) = CreateMecanumJacobianRow(rollerDirection, wheelPosition);
+                    setRow(CreateMecanumJacobianRow(m_rollerDirections[i], wheelPosition));
                 }
                 else if (m_animationType == AnimationType::Differential)
                 {
-                    m_jacobian.row(i) = CreateDifferentialJacobianRow(wheelPosition);
+                    setRow(CreateDifferentialJacobianRow(wheelPosition));
                 }
                 else
                 {
                     AZ_Error("WheelAnimComponent", false, "Unknown animation type");
-                    m_jacobian.row(i) = Eigen::Vector3d::Zero();
+                    setRow(AZ::Vector3::CreateZero());
                 }
             }
         }
@@ -306,7 +291,7 @@ namespace WheelAnimTool
 
     void WheelAnimComponent::OnTick(float deltaTime, AZ::ScriptTimePoint time)
     {
-        if (m_jacobian.size() == 0)
+        if (m_jacobian.GetRowCount() == 0)
         {
             if (!InitJacobian())
             {
@@ -332,13 +317,16 @@ namespace WheelAnimTool
             DrawVector(m_drawQueue, GetEntity()->GetTransform()->GetWorldTM(), AZ::Colors::Green, angularVelocityLoc);
         }
 
-        Eigen::Vector3d robotState;
-        robotState << linearVelocityLoc.GetX(), linearVelocityLoc.GetY(), angularVelocityLoc.GetZ();
-        Eigen::VectorXd wheelSpeeds = m_jacobian * robotState;
+        AZ::VectorN robotState(3);
+        robotState.SetElement(0, linearVelocityLoc.GetX());
+        robotState.SetElement(1, linearVelocityLoc.GetY());
+        robotState.SetElement(2, angularVelocityLoc.GetZ());
+        AZ::VectorN wheelSpeeds(m_jacobian.GetRowCount());
+        AZ::VectorMatrixMultiply(m_jacobian, robotState, wheelSpeeds);
 
-        for (int i = 0; i < wheelSpeeds.size(); ++i)
+        for (int i = 0; i < static_cast<int>(wheelSpeeds.GetDimensionality()); ++i)
         {
-            const float wheelSpeed = static_cast<float>(wheelSpeeds(i));
+            const float wheelSpeed = wheelSpeeds.GetElement(i);
 
             AZ::Transform wheelTransform = AZ::Transform::CreateIdentity();
             AZ::TransformBus::EventResult(wheelTransform, m_wheelEntities[i], &AZ::TransformInterface::GetWorldTM);

--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
@@ -11,6 +11,7 @@
 #include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Scene.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Math/VectorN.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
@@ -18,7 +19,6 @@
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <AzCore/Math/VectorN.h>
 namespace WheelAnimTool
 {
 

--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.cpp
@@ -177,6 +177,7 @@ namespace WheelAnimTool
     {
         AZ::TickBus::Handler::BusDisconnect();
         m_jacobian = Eigen::MatrixXd();
+        m_wheelAxisSign.clear();
     }
 
     //! \brief Create a row of the Jacobian matrix for a mecanum wheel.
@@ -258,17 +259,6 @@ namespace WheelAnimTool
             meanWheelPosition += EigenO3DE::ToEigen(wheelPosLoc);
             wheelPositions.row(i) = EigenO3DE::ToEigen(wheelPosLoc);
         }
-
-        for (int i = 0; i < numWheels; ++i)
-        {
-            const AZ::EntityId wheelEntity = m_wheelEntities[i];
-            AZ::Vector3 wheelPos = AZ::Vector3::CreateZero();
-            AZ::TransformBus::EventResult(wheelPos, wheelEntity, &AZ::TransformInterface::GetWorldTranslation);
-            // transform wheel position to local space
-            const AZ::Vector3 wheelPosLoc = worldTransformInv.TransformPoint(wheelPos);
-            meanWheelPosition += EigenO3DE::ToEigen(wheelPosLoc);
-            wheelPositions.row(i) = EigenO3DE::ToEigen(wheelPosLoc);
-        }
         meanWheelPosition /= numWheels;
 
         // calculate location w.r.t the mean wheel position
@@ -281,9 +271,20 @@ namespace WheelAnimTool
         {
             // update jacobian matrix size
             m_jacobian = Eigen::MatrixXd(numWheels, 3); // we transform 3D speed to 1D speed of wheel
+            m_wheelAxisSign.resize(numWheels);
+            const AZ::Vector3 robotAxisInWorld = worldTransform.TransformVector(m_wheelAxis);
             for (int i = 0; i < numWheels; ++i)
             {
                 const Eigen::Vector3d wheelPosition = wheelPositions.row(i);
+
+                // Detect mirrored wheel meshes (e.g. 180 deg X flip reusing the same mesh for both sides).
+                // If the wheel's spin axis opposes the robot body's spin axis, the rotation angle must be
+                // negated so that a positive wheel speed always produces a visually forward roll.
+                AZ::Transform wheelTM = AZ::Transform::CreateIdentity();
+                AZ::TransformBus::EventResult(wheelTM, m_wheelEntities[i], &AZ::TransformInterface::GetWorldTM);
+                const AZ::Vector3 wheelAxisInWorld = wheelTM.TransformVector(m_wheelAxis);
+                m_wheelAxisSign[i] = (robotAxisInWorld.Dot(wheelAxisInWorld) >= 0.f) ? 1.f : -1.f;
+
                 if (m_animationType == AnimationType::Mecanum)
                 {
                     const Eigen::Vector2d rollerDirection = EigenO3DE::ToEigen(m_rollerDirections[i]);
@@ -342,7 +343,7 @@ namespace WheelAnimTool
             AZ::Transform wheelTransform = AZ::Transform::CreateIdentity();
             AZ::TransformBus::EventResult(wheelTransform, m_wheelEntities[i], &AZ::TransformInterface::GetWorldTM);
 
-            const float wheelAngle = (wheelSpeed / m_wheelRadius) * deltaTime; // angle in radians
+            const float wheelAngle = m_wheelAxisSign[i] * (wheelSpeed / m_wheelRadius) * deltaTime; // angle in radians
             const AZ::Quaternion wheelRotationIncrement = AZ::Quaternion::CreateFromAxisAngle(m_wheelAxis, wheelAngle);
             const AZ::Quaternion newWheelRotation = wheelTransform.GetRotation() * wheelRotationIncrement;
             const AZ::Quaternion newWheelRotationNormalized = newWheelRotation.GetNormalized();

--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.h
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.h
@@ -18,7 +18,7 @@
 #include <Atom/RPI.Public/AuxGeom/AuxGeomDraw.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
-#include <Eigen/Dense>
+#include <AzCore/Math/MatrixMxN.h>
 namespace WheelAnimTool
 {
     enum class AnimationType
@@ -55,7 +55,7 @@ namespace WheelAnimTool
         float m_wheelRadius = 0.1f; // Radius of the wheel for drawing purposes
 
         bool InitJacobian(); //< Initialize the Jacobian matrix based on wheel directions and animation type
-        Eigen::MatrixXd m_jacobian; // Jacobian matrix of size (numWheels, 3) for 3D to 1D speed transform
+        AZ::MatrixMxN m_jacobian; // Jacobian matrix of size (numWheels, 3) for 3D to 1D speed transform
         AZStd::vector<float> m_wheelAxisSign; // +1 or -1 per wheel: compensates for mirrored mesh transforms
         AZ::RPI::AuxGeomDrawPtr m_drawQueue;
     };

--- a/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.h
+++ b/Gems/WheelAnimTool/Code/Source/Clients/WheelAnimComponent.h
@@ -56,6 +56,7 @@ namespace WheelAnimTool
 
         bool InitJacobian(); //< Initialize the Jacobian matrix based on wheel directions and animation type
         Eigen::MatrixXd m_jacobian; // Jacobian matrix of size (numWheels, 3) for 3D to 1D speed transform
+        AZStd::vector<float> m_wheelAxisSign; // +1 or -1 per wheel: compensates for mirrored mesh transforms
         AZ::RPI::AuxGeomDrawPtr m_drawQueue;
     };
 } // namespace WheelAnimTool

--- a/Gems/WheelAnimTool/gem.json
+++ b/Gems/WheelAnimTool/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "WheelAnimTool",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "display_name": "WheelAnimTool",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/Gems/WheelAnimTool/readme.md
+++ b/Gems/WheelAnimTool/readme.md
@@ -15,10 +15,7 @@ The WheelAnimTool is an O3DE gem that provides realistic wheel animation for rob
 
 ## Prerequisites
 
-It requires O3DE Engine and the Eigen library for matrix operations.
-```shell
-sudo apt install libeigen3-dev
-```
+Requires O3DE Engine. No additional libraries are needed — all math operations use `AZ::MatrixMxN` and `AZ::VectorN` from `AzCore`, which is a standard O3DE dependency.
 
 ## Installation
 
@@ -103,22 +100,22 @@ Traditional two-wheel drive system where:
 ### Key Algorithms
 
 #### Jacobian Matrix Calculation
-The component uses a Jacobian matrix to transform 3D robot velocity to 1D wheel speeds:
+The component uses an `AZ::MatrixMxN` Jacobian to transform 3D robot velocity to per-wheel speeds. Each row encodes one wheel's kinematic contribution:
 
 ```cpp
-// For mecanum wheels
-jacobianRow << rollerDirection.x(), rollerDirection.y(), (wheelPosition.x() + abs(2.0*wheelPosition.y()));
-
-// For differential drive
-jacobianRow << 1.0, 0.0, wheelPosition.y();
+// For mecanum wheels: [roller_dir_x, roller_dir_y, ±(Lx+Ly)/2]
+// For differential drive: [1, 0, ±Lx/2]
 ```
+
+where `Lx` is the track width and `Ly` is the wheelbase, both derived from wheel positions relative to the geometric center.
 
 #### Wheel Speed Calculation
 ```cpp
-Eigen::VectorXd wheelSpeeds = m_jacobian * robotState;
+AZ::VectorN wheelSpeeds(numWheels);
+AZ::VectorMatrixMultiply(m_jacobian, robotState, wheelSpeeds);
 ```
 
-Where `robotState` contains `[linear_x, linear_y, angular_z]` velocities.
+Where `robotState` is an `AZ::VectorN(3)` containing `[linear_x, linear_y, angular_z]` velocities.
 
 ## Debug Visualization
 
@@ -131,15 +128,13 @@ When debug drawing is enabled, the component displays:
 
 ## Dependencies
 
-- **O3DE Framework**: Core engine functionality
-- **Eigen Library**: Mathematical operations and matrix calculations
+- **O3DE Framework**: Core engine functionality (`AzCore`, `AzFramework`)
 - **AzFramework Physics**: Rigid body integration
 - **Atom Renderer**: Debug visualization
 
 ## Technical Requirements
 
 - O3DE Engine compatible version
-- Eigen mathematical library
 - Entity must have a rigid body component for physics integration
 - Wheel entities must be properly configured as child entities
 

--- a/Gems/WheelAnimTool/readme.md
+++ b/Gems/WheelAnimTool/readme.md
@@ -8,6 +8,7 @@ The WheelAnimTool is an O3DE gem that provides realistic wheel animation for rob
 
 - **Multiple Drive Types**: Supports mecanum and differential drive systems
 - **Physics Integration**: Automatically calculates wheel speeds based on rigid body velocity
+- **Mirrored Mesh Support**: Automatically compensates for wheel meshes that reuse the same asset on both sides via a transform flip
 - **Visual Debugging**: Real-time visualization of wheel speeds and robot motion
 - **Configurable Parameters**: Adjustable wheel radius, roller directions, and animation types
 - **Jacobian-based Kinematics**: Uses mathematical models for accurate wheel speed calculations


### PR DESCRIPTION
## What does this PR do?

- **Fix duplicate wheel position loop in `InitJacobian`**: the position-gathering loop ran twice, causing `meanWheelPosition` to accumulate 2x the correct sum and shifting all relative wheel positions
- **Auto-compensate for mirrored wheel meshes**: added per-wheel `m_wheelAxisSign` computed at activation by comparing each wheel entity's spin axis direction against the robot body's spin axis
- **Remove Eigen dependency, replace with `AZ::Math`**:
  - `Eigen::MatrixXd` -> `AZ::MatrixMxN`
  - `Eigen::VectorXd` -> `AZ::VectorN`
  - `Eigen::Vector3d` / `Eigen::Vector2d` -> `AZ::Vector3` / `AZ::Vector2`
  - Matrix-vector multiply -> `AZ::VectorMatrixMultiply`

Removing Eigen was done to solve https://github.com/RobotecAI/agentic-mobile-manipulator/pull/31

The version of the Gem was updated to `2.0.0`, as 1.x.y serie is used for o3de-2505 branch.

---

## How was this PR tested?

Tested using https://github.com/RobotecAI/agentic-mobile-manipulator/ demo project
The Robot needed updates of the controller:
<img width="408" height="203" alt="Screenshot from 2026-06-29 12-59-02" src="https://github.com/user-attachments/assets/9d650708-9adf-4733-9c47-99ced6c1566c" />

---

## Screenshots / Logs / Supporting Evidence (if applicable)

https://github.com/user-attachments/assets/1a9527da-1a9c-4d46-aa17-9bfe9a76f453

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [x] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [x] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
