### PR TITLE
[2605] porting ImGuiProvider Gem to o3de 2605

### DIFF
--- a/Gems/ImGuiProvider/Code/Source/Utils/MenuTreeUtilities.cpp
+++ b/Gems/ImGuiProvider/Code/Source/Utils/MenuTreeUtilities.cpp
@@ -95,7 +95,7 @@ namespace ImGuiProvider
             {
                 current = current->GetChildPtr(level.String()); // Move to the child node
             }
-            parentNodes.push_back(AZStd::make_pair(current, level));
+            parentNodes.emplace_back(AZStd::make_pair(current, level));
         }
         return parentNodes;
     }

--- a/Gems/ImGuiProvider/Code/Source/Utils/MenuTreeUtilities.cpp
+++ b/Gems/ImGuiProvider/Code/Source/Utils/MenuTreeUtilities.cpp
@@ -95,7 +95,7 @@ namespace ImGuiProvider
             {
                 current = current->GetChildPtr(level.String()); // Move to the child node
             }
-            parentNodes.emplace_back(AZStd::make_pair(current, level));
+            parentNodes.emplace_back(current, level);
         }
         return parentNodes;
     }

--- a/Gems/ImGuiProvider/gem.json
+++ b/Gems/ImGuiProvider/gem.json
@@ -1,6 +1,6 @@
 {
     "gem_name": "ImGuiProvider",
-    "version": "2.0.0",
+    "version": "3.0.0",
     "display_name": "ImGuiProvider",
     "license": "Apache-2.0",
     "license_url": "https://opensource.org/licenses/Apache-2.0",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Note that this is not a "Canonical" part of O3DE - those gems are third-party co
 | ----------------------------------------------------------- | ------------- |
 | [**CsvSpawner**](#csvspawner)                               | not verified  |
 | [**ExposeConsoleToRos**](#exposeconsoletoRos)               | not verified  |
-| [**ImGuiProvider**](#imguiprovider)                         | not verified  |
+| [**ImGuiProvider**](#imguiprovider)                         | compatible    |
 | [**ImGuizmo**](#imguizmo)                                   | not verified  |
 | [**LevelModificationTools**](#levelmodificationtools)       | not verified  |
 | [**Pointcloud**](#pointcloud)                               | compatible    |


### PR DESCRIPTION
## What does this PR do?

This PR ports ImGuiProvider Gem to o3de 2605. 
It bumps gem major version and marks it as compatible

---

## How was this PR tested?

I built test project with gem using ImGuiProvider's buses and component. Project built and worked as expected

---

## Committer Checklist

Please confirm the following before marking this PR as ready for review:

- [ ] Code changes are well-documented
- [ ] Tests have been added or updated
- [ ] Code owners file and CI config were updated if new Gem was added
- [x] The code is formatted according to the project's style guide
- [x] The version number has been updated according to the contributing guidelines
